### PR TITLE
Passing the ABI to underlying libraries to apply to respective routes.

### DIFF
--- a/Assets/Thirdweb/Scripts/Contract.cs
+++ b/Assets/Thirdweb/Scripts/Contract.cs
@@ -27,13 +27,14 @@ namespace Thirdweb
         /// </summary>
         public Marketplace marketplace;
 
-        public Contract(string chain, string address, string abi = null) {
+        public Contract(string chain, string address, string abi = null)
+        {
             this.chain = chain;
             this.address = address;
             this.abi = abi;
-            this.ERC20 = new ERC20(chain, address);
-            this.ERC721 = new ERC721(chain, address);
-            this.ERC1155 = new ERC1155(chain, address);
+            this.ERC20 = new ERC20(chain, address, abi);
+            this.ERC721 = new ERC721(chain, address, abi);
+            this.ERC1155 = new ERC1155(chain, address, abi);
             this.marketplace = new Marketplace(chain, address);
         }
 
@@ -45,7 +46,7 @@ namespace Thirdweb
         /// <returns>The data deserialized to the given typed</returns>
         public async Task<T> Read<T>(string functionName, params object[] args)
         {
-            string [] argsEncoded = new string[args.Length + 1];
+            string[] argsEncoded = new string[args.Length + 1];
             argsEncoded[0] = functionName;
             Utils.ToJsonStringArray(args).CopyTo(argsEncoded, 1);
             return await Bridge.InvokeRoute<T>(getRoute("call"), argsEncoded);
@@ -59,18 +60,15 @@ namespace Thirdweb
         /// <returns>The transaction receipt</returns>
         public async Task<TransactionResult> Write(string functionName, params object[] args)
         {
-            string [] argsEncoded = new string[args.Length + 1];
+            string[] argsEncoded = new string[args.Length + 1];
             argsEncoded[0] = functionName;
             Utils.ToJsonStringArray(args).CopyTo(argsEncoded, 1);
             return await Bridge.InvokeRoute<TransactionResult>(getRoute("call"), argsEncoded);
         }
 
-        private string getRoute(string functionPath) {
-            if (abi != null) {
-                return this.address + "#" + abi + "." + functionPath;
-            } else {
-                return this.address + "." + functionPath;
-            }
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + "." + functionPath : this.address + "." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/Contract.cs
+++ b/Assets/Thirdweb/Scripts/Contract.cs
@@ -27,7 +27,7 @@ namespace Thirdweb
         /// </summary>
         public Marketplace marketplace;
 
-        public Contract(string chain, string address, string abi = null)
+        public Contract(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -68,7 +68,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + "." + functionPath : this.address + "." + functionPath;
+            return abi != "" ? this.address + "#" + abi + "." + functionPath : this.address + "." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/ERC1155.cs
+++ b/Assets/Thirdweb/Scripts/ERC1155.cs
@@ -11,6 +11,7 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
         /// <summary>
         /// Handle signature minting functionality
         /// </summary>
@@ -187,11 +188,13 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
 
-        public ERC1155ClaimConditions(string chain, string address)
+        public ERC1155ClaimConditions(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
         }
 
         /// <summary>
@@ -328,11 +331,13 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
 
-        public ERC1155Signature(string chain, string address)
+        public ERC1155Signature(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
         }
 
         public async Task<ERC1155SignedPayload> Generate(ERC1155MintPayload payloadToSign)

--- a/Assets/Thirdweb/Scripts/ERC1155.cs
+++ b/Assets/Thirdweb/Scripts/ERC1155.cs
@@ -29,8 +29,8 @@ namespace Thirdweb
             this.chain = chain;
             this.address = address;
             this.abi = abi;
-            this.signature = new ERC1155Signature(chain, address);
-            this.claimConditions = new ERC1155ClaimConditions(chain, address);
+            this.signature = new ERC1155Signature(chain, address, abi);
+            this.claimConditions = new ERC1155ClaimConditions(chain, address, abi);
         }
 
         // READ FUNCTIONS

--- a/Assets/Thirdweb/Scripts/ERC1155.cs
+++ b/Assets/Thirdweb/Scripts/ERC1155.cs
@@ -24,7 +24,7 @@ namespace Thirdweb
         /// <summary>
         /// Interact with any ERC1155 compatible contract.
         /// </summary>
-        public ERC1155(string chain, string address, string abi = null)
+        public ERC1155(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -177,7 +177,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc1155." + functionPath : this.address + ".erc1155." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc1155." + functionPath : this.address + ".erc1155." + functionPath;
         }
     }
 
@@ -190,7 +190,7 @@ namespace Thirdweb
         public string address;
         public string abi;
 
-        public ERC1155ClaimConditions(string chain, string address, string abi = null)
+        public ERC1155ClaimConditions(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -231,7 +231,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc1155.claimConditions." + functionPath : this.address + ".erc1155.claimConditions." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc1155.claimConditions." + functionPath : this.address + ".erc1155.claimConditions." + functionPath;
         }
     }
 
@@ -333,7 +333,7 @@ namespace Thirdweb
         public string address;
         public string abi;
 
-        public ERC1155Signature(string chain, string address, string abi = null)
+        public ERC1155Signature(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -362,7 +362,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc1155.signature." + functionPath : this.address + ".erc1155.signature." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc1155.signature." + functionPath : this.address + ".erc1155.signature." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/ERC1155.cs
+++ b/Assets/Thirdweb/Scripts/ERC1155.cs
@@ -15,7 +15,7 @@ namespace Thirdweb
         /// Handle signature minting functionality
         /// </summary>
         public ERC1155Signature signature;
-                /// <summary>
+        /// <summary>
         /// Query claim conditions
         /// </summary>
         public ERC1155ClaimConditions claimConditions;
@@ -23,10 +23,11 @@ namespace Thirdweb
         /// <summary>
         /// Interact with any ERC1155 compatible contract.
         /// </summary>
-        public ERC1155(string chain, string address)
+        public ERC1155(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
             this.signature = new ERC1155Signature(chain, address);
             this.claimConditions = new ERC1155ClaimConditions(chain, address);
         }
@@ -69,7 +70,7 @@ namespace Thirdweb
         /// <summary>
         /// Get the balance of the given NFT for the given wallet address
         /// </summary>
-        public async Task<string> BalanceOf(string address, string tokenId) 
+        public async Task<string> BalanceOf(string address, string tokenId)
         {
             return await Bridge.InvokeRoute<string>(getRoute("balanceOf"), Utils.ToJsonStringArray(address, tokenId));
         }
@@ -173,12 +174,13 @@ namespace Thirdweb
 
         // PRIVATE
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc1155." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc1155." + functionPath : this.address + ".erc1155." + functionPath;
         }
     }
 
-     /// <summary>
+    /// <summary>
     /// Fetch claim conditions for a given ERC1155 drop contract
     /// </summary>
     public class ERC1155ClaimConditions
@@ -224,14 +226,15 @@ namespace Thirdweb
             return await Bridge.InvokeRoute<bool>(getRoute("getClaimerProofs"), Utils.ToJsonStringArray(claimerAddress));
         }
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc1155.claimConditions." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc1155.claimConditions." + functionPath : this.address + ".erc1155.claimConditions." + functionPath;
         }
     }
 
     // TODO switch to another JSON serializer that supports polymorphism
     [System.Serializable]
-    #nullable enable
+#nullable enable
     public class ERC1155MintPayload
     {
         public string to;
@@ -247,7 +250,8 @@ namespace Thirdweb
         // public long mintStartTime;
         // public long mintEndTime;
 
-        public ERC1155MintPayload(string receiverAddress, NFTMetadata metadata) {
+        public ERC1155MintPayload(string receiverAddress, NFTMetadata metadata)
+        {
             this.metadata = metadata;
             this.to = receiverAddress;
             this.price = "0";
@@ -279,7 +283,8 @@ namespace Thirdweb
         // public long mintStartTime;
         // public long mintEndTime;
 
-        public ERC1155MintAdditionalPayload(string receiverAddress, string tokenId) {
+        public ERC1155MintAdditionalPayload(string receiverAddress, string tokenId)
+        {
             this.tokenId = tokenId;
             this.to = receiverAddress;
             this.price = "0";
@@ -350,8 +355,9 @@ namespace Thirdweb
             return await Bridge.InvokeRoute<TransactionResult>(getRoute("mint"), Utils.ToJsonStringArray(signedPayload));
         }
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc1155.signature." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc1155.signature." + functionPath : this.address + ".erc1155.signature." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/ERC20.cs
+++ b/Assets/Thirdweb/Scripts/ERC20.cs
@@ -28,8 +28,8 @@ namespace Thirdweb
             this.chain = chain;
             this.address = address;
             this.abi = abi;
-            this.signature = new ERC20Signature(chain, address);
-            this.claimConditions = new ERC20ClaimConditions(chain, address);
+            this.signature = new ERC20Signature(chain, address, abi);
+            this.claimConditions = new ERC20ClaimConditions(chain, address, abi);
         }
 
         // READ FUNCTIONS

--- a/Assets/Thirdweb/Scripts/ERC20.cs
+++ b/Assets/Thirdweb/Scripts/ERC20.cs
@@ -10,6 +10,7 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
         /// <summary>
         /// Handle signature minting functionality
         /// </summary>
@@ -202,11 +203,13 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
 
-        public ERC20ClaimConditions(string chain, string address)
+        public ERC20ClaimConditions(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
         }
 
 
@@ -256,14 +259,16 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
 
         /// <summary>
         /// Generate, verify and mint signed mintable payloads
         /// </summary>
-        public ERC20Signature(string chain, string address)
+        public ERC20Signature(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
         }
 
         /// <summary>

--- a/Assets/Thirdweb/Scripts/ERC20.cs
+++ b/Assets/Thirdweb/Scripts/ERC20.cs
@@ -22,10 +22,11 @@ namespace Thirdweb
         /// <summary>
         /// Interact with any ERC20 compatible contract.
         /// </summary>
-        public ERC20(string chain, string address)
+        public ERC20(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = null;
             this.signature = new ERC20Signature(chain, address);
             this.claimConditions = new ERC20ClaimConditions(chain, address);
         }
@@ -140,13 +141,14 @@ namespace Thirdweb
 
         // PRIVATE
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc20." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc20." + functionPath : this.address + ".erc20." + functionPath;
         }
     }
 
     [System.Serializable]
-    #nullable enable
+#nullable enable
     public class ERC20MintPayload
     {
         public string to;
@@ -159,7 +161,8 @@ namespace Thirdweb
         // public long mintStartTime;
         // public long mintEndTime;
 
-        public ERC20MintPayload(string receiverAddress, string quantity) {
+        public ERC20MintPayload(string receiverAddress, string quantity)
+        {
             this.to = receiverAddress;
             this.quantity = quantity;
             this.price = "0";
@@ -239,8 +242,9 @@ namespace Thirdweb
             return await Bridge.InvokeRoute<bool>(getRoute("getClaimerProofs"), Utils.ToJsonStringArray(claimerAddress));
         }
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc20.claimConditions." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc20.claimConditions." + functionPath : this.address + ".erc20.claimConditions." + functionPath;
         }
     }
 
@@ -286,8 +290,9 @@ namespace Thirdweb
             return await Bridge.InvokeRoute<TransactionResult>(getRoute("mint"), Utils.ToJsonStringArray(signedPayload));
         }
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc20.signature." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc20.signature." + functionPath : this.address + ".erc20.signature." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/ERC20.cs
+++ b/Assets/Thirdweb/Scripts/ERC20.cs
@@ -23,11 +23,11 @@ namespace Thirdweb
         /// <summary>
         /// Interact with any ERC20 compatible contract.
         /// </summary>
-        public ERC20(string chain, string address, string abi = null)
+        public ERC20(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
-            this.abi = null;
+            this.abi = abi;
             this.signature = new ERC20Signature(chain, address);
             this.claimConditions = new ERC20ClaimConditions(chain, address);
         }
@@ -144,7 +144,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc20." + functionPath : this.address + ".erc20." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc20." + functionPath : this.address + ".erc20." + functionPath;
         }
     }
 
@@ -205,7 +205,7 @@ namespace Thirdweb
         public string address;
         public string abi;
 
-        public ERC20ClaimConditions(string chain, string address, string abi = null)
+        public ERC20ClaimConditions(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -247,7 +247,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc20.claimConditions." + functionPath : this.address + ".erc20.claimConditions." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc20.claimConditions." + functionPath : this.address + ".erc20.claimConditions." + functionPath;
         }
     }
 
@@ -264,7 +264,7 @@ namespace Thirdweb
         /// <summary>
         /// Generate, verify and mint signed mintable payloads
         /// </summary>
-        public ERC20Signature(string chain, string address, string abi = null)
+        public ERC20Signature(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -297,7 +297,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc20.signature." + functionPath : this.address + ".erc20.signature." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc20.signature." + functionPath : this.address + ".erc20.signature." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/ERC721.cs
+++ b/Assets/Thirdweb/Scripts/ERC721.cs
@@ -23,10 +23,11 @@ namespace Thirdweb
         /// <summary>
         /// Interact with any ERC721 compatible contract.
         /// </summary>
-        public ERC721(string chain, string address)
+        public ERC721(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = null;
             this.signature = new ERC721Signature(chain, address);
             this.claimConditions = new ERC721ClaimConditions(chain, address);
         }
@@ -176,8 +177,9 @@ namespace Thirdweb
 
         // PRIVATE
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc721." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc721." + functionPath : this.address + ".erc721." + functionPath;
         }
     }
 
@@ -228,13 +230,14 @@ namespace Thirdweb
             return await Bridge.InvokeRoute<bool>(getRoute("getClaimerProofs"), Utils.ToJsonStringArray(claimerAddress));
         }
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc721.claimConditions." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc721.claimConditions." + functionPath : this.address + ".erc721.claimConditions." + functionPath;
         }
     }
 
     [System.Serializable]
-    #nullable enable
+#nullable enable
     public class ERC721MintPayload
     {
         public string to;
@@ -250,7 +253,8 @@ namespace Thirdweb
         // public long mintStartTime;
         // public long mintEndTime;
 
-        public ERC721MintPayload(string receiverAddress, NFTMetadata metadata) {
+        public ERC721MintPayload(string receiverAddress, NFTMetadata metadata)
+        {
             this.metadata = metadata;
             this.to = receiverAddress;
             this.price = "0";
@@ -315,8 +319,9 @@ namespace Thirdweb
             return await Bridge.InvokeRoute<TransactionResult>(getRoute("mint"), Utils.ToJsonStringArray(signedPayload));
         }
 
-        private string getRoute(string functionPath) {
-            return this.address + ".erc721.signature." + functionPath;
+        private string getRoute(string functionPath)
+        {
+            return abi != null ? this.address + "#" + abi + ".erc721.signature." + functionPath : this.address + ".erc721.signature." + functionPath;
         }
     }
 }

--- a/Assets/Thirdweb/Scripts/ERC721.cs
+++ b/Assets/Thirdweb/Scripts/ERC721.cs
@@ -29,8 +29,8 @@ namespace Thirdweb
             this.chain = chain;
             this.address = address;
             this.abi = abi;
-            this.signature = new ERC721Signature(chain, address);
-            this.claimConditions = new ERC721ClaimConditions(chain, address);
+            this.signature = new ERC721Signature(chain, address, abi);
+            this.claimConditions = new ERC721ClaimConditions(chain, address, abi);
         }
 
         // READ FUNCTIONS

--- a/Assets/Thirdweb/Scripts/ERC721.cs
+++ b/Assets/Thirdweb/Scripts/ERC721.cs
@@ -11,6 +11,7 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
         /// <summary>
         /// Handle signature minting functionality
         /// </summary>
@@ -190,11 +191,13 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
 
-        public ERC721ClaimConditions(string chain, string address)
+        public ERC721ClaimConditions(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
         }
 
 
@@ -297,11 +300,13 @@ namespace Thirdweb
     {
         public string chain;
         public string address;
+        public string abi;
 
-        public ERC721Signature(string chain, string address)
+        public ERC721Signature(string chain, string address, string abi = null)
         {
             this.chain = chain;
             this.address = address;
+            this.abi = abi;
         }
 
         public async Task<ERC721SignedPayload> Generate(ERC721MintPayload payloadToSign)

--- a/Assets/Thirdweb/Scripts/ERC721.cs
+++ b/Assets/Thirdweb/Scripts/ERC721.cs
@@ -24,11 +24,11 @@ namespace Thirdweb
         /// <summary>
         /// Interact with any ERC721 compatible contract.
         /// </summary>
-        public ERC721(string chain, string address, string abi = null)
+        public ERC721(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
-            this.abi = null;
+            this.abi = abi;
             this.signature = new ERC721Signature(chain, address);
             this.claimConditions = new ERC721ClaimConditions(chain, address);
         }
@@ -180,7 +180,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc721." + functionPath : this.address + ".erc721." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc721." + functionPath : this.address + ".erc721." + functionPath;
         }
     }
 
@@ -193,7 +193,7 @@ namespace Thirdweb
         public string address;
         public string abi;
 
-        public ERC721ClaimConditions(string chain, string address, string abi = null)
+        public ERC721ClaimConditions(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -235,7 +235,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc721.claimConditions." + functionPath : this.address + ".erc721.claimConditions." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc721.claimConditions." + functionPath : this.address + ".erc721.claimConditions." + functionPath;
         }
     }
 
@@ -302,7 +302,7 @@ namespace Thirdweb
         public string address;
         public string abi;
 
-        public ERC721Signature(string chain, string address, string abi = null)
+        public ERC721Signature(string chain, string address, string abi = "")
         {
             this.chain = chain;
             this.address = address;
@@ -326,7 +326,7 @@ namespace Thirdweb
 
         private string getRoute(string functionPath)
         {
-            return abi != null ? this.address + "#" + abi + ".erc721.signature." + functionPath : this.address + ".erc721.signature." + functionPath;
+            return abi != "" ? this.address + "#" + abi + ".erc721.signature." + functionPath : this.address + ".erc721.signature." + functionPath;
         }
     }
 }


### PR DESCRIPTION
This allows the use of ERC20, ERC721, ERC1155 shorthands with custom contracts implementing said interfaces.