### PR TITLE
Cleanup connect api + remove supportedNetworks from wallet prefabs

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Bridge.cs
+++ b/Assets/Thirdweb/Core/Scripts/Bridge.cs
@@ -91,7 +91,7 @@ namespace Thirdweb
             string taskId = Guid.NewGuid().ToString();
             taskMap[taskId] = task;
 #if UNITY_WEBGL
-            ThirdwebConnect(taskId, walletConnection.provider.ToString(), walletConnection.chainId, walletConnection.password ?? Utils.GetDeviceIdentifier(), jsCallback);
+            ThirdwebConnect(taskId, walletConnection.provider.ToString().Substring(0,1).ToLower() + walletConnection.provider.ToString().Substring(1), walletConnection.chainId, walletConnection.password ?? Utils.GetDeviceIdentifier(), jsCallback);
 #endif
             string result = await task.Task;
             return result;

--- a/Assets/Thirdweb/Core/Scripts/Utils.cs
+++ b/Assets/Thirdweb/Core/Scripts/Utils.cs
@@ -261,7 +261,21 @@ namespace Thirdweb
             return Application.persistentDataPath + "/account.json";
         }
 
-        public static Account UnlockOrGenerateAccount(int chainId, string password = null, string privateKey = null)
+        public static bool DeleteLocalAccount()
+        {
+            try
+            {
+                File.Delete(GetAccountPath());
+                return true;
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning("Error deleting account: " + e.Message);
+                return false;
+            }
+        }
+
+        public static Account UnlockOrGenerateLocalAccount(int chainId, string password = null, string privateKey = null)
         {
             password ??= GetDeviceIdentifier();
 

--- a/Assets/Thirdweb/Examples/Prefabs/Prefab_ConnectWallet.prefab
+++ b/Assets/Thirdweb/Examples/Prefabs/Prefab_ConnectWallet.prefab
@@ -306,10 +306,10 @@ RectTransform:
   m_Father: {fileID: 1335404547797609897}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -165}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &351517273
 CanvasRenderer:
@@ -411,7 +411,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &472489314
 RectTransform:
   m_ObjectHideFlags: 0
@@ -600,10 +600,10 @@ RectTransform:
   m_Father: {fileID: 1335404547797609897}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -230}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &679192017
 CanvasRenderer:
@@ -934,10 +934,10 @@ RectTransform:
   m_Father: {fileID: 1335404547797609897}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -100}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1045367079
 CanvasRenderer:
@@ -1897,22 +1897,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   supportedWallets: 01000000020000000300000005000000
-  supportSwitchingNetwork: 1
-  supportedNetworks:
-  - ethereum
-  - goerli
-  - polygon
-  - mumbai
-  - fantom
-  - fantom-testnet
-  - avalanche
-  - avalanche-fuji
-  - optimism
-  - optimism-goerli
-  - arbitrum
-  - arbitrum-goerli
-  - binance
-  - binance-testnet
   OnConnectedCallback:
     m_PersistentCalls:
       m_Calls: []
@@ -1934,13 +1918,13 @@ MonoBehaviour:
   connectButton: {fileID: 1335404547334051784}
   connectDropdown: {fileID: 1335404547797609896}
   walletButtons:
-  - wallet: 1
+  - wallet: 3
     walletButton: {fileID: 1335404546759128316}
     icon: {fileID: 21300000, guid: 217680bfb64fc074392309113986a3ee, type: 3}
-  - wallet: 2
+  - wallet: 1
     walletButton: {fileID: 1045367075}
     icon: {fileID: 21300000, guid: 3e92fa75bd5ab3047974f1a4f9dc4832, type: 3}
-  - wallet: 3
+  - wallet: 2
     walletButton: {fileID: 351517269}
     icon: {fileID: 21300000, guid: d5a5e5db03872be4c8c6303a906b29bd, type: 3}
   - wallet: 4
@@ -1960,7 +1944,8 @@ MonoBehaviour:
   currentNetworkText: {fileID: 270904384543002881}
   currentNetworkImage: {fileID: 1390862793022922592}
   chainImage: {fileID: 4426890310649894616}
-  networkSwitchButton: {fileID: 0}
+  networkSwitchButton: {fileID: 4685202618896491808}
+  networkSwitchImage: {fileID: 3483875505141020193}
   networkDropdown: {fileID: 8325283099334609011}
   networkButtonPrefab: {fileID: 6070093235809079241, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
   networkSprites:
@@ -2028,10 +2013,10 @@ RectTransform:
   m_Father: {fileID: 1335404547797609897}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -35}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1335404546759128312
 CanvasRenderer:
@@ -2403,7 +2388,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1335404547334051785
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2552,7 +2537,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -25, y: -75}
-  m_SizeDelta: {x: 50, y: 330}
+  m_SizeDelta: {x: 50, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1335404547797609893
 CanvasRenderer:
@@ -3355,7 +3340,7 @@ GameObject:
   - component: {fileID: 5961775450661705162}
   - component: {fileID: 5139406429550996692}
   m_Layer: 5
-  m_Name: Button_DeviceWallet
+  m_Name: Button_LocalWallet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3378,10 +3363,10 @@ RectTransform:
   m_Father: {fileID: 1335404547797609897}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -295}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4602955866666427568
 CanvasRenderer:
@@ -3688,7 +3673,7 @@ GameObject:
   - component: {fileID: 6845095577872559985}
   - component: {fileID: 3224114940685379019}
   m_Layer: 5
-  m_Name: Image_DeviceWallet
+  m_Name: Image_LocalWallet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4110,7 +4095,7 @@ GameObject:
   - component: {fileID: 7285337750100448865}
   - component: {fileID: 7486429459922162202}
   m_Layer: 5
-  m_Name: Text_DeviceWallet
+  m_Name: Text_LocalWallet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4164,7 +4149,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Device Wallet
+  m_text: Local Wallet
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -4275,7 +4260,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: -50}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 150}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &8856659653986850489
 CanvasRenderer:
@@ -4534,7 +4519,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMin.x
@@ -4542,11 +4527,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_SizeDelta.y
@@ -4582,11 +4567,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -75
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4636,7 +4621,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMin.x
@@ -4644,11 +4629,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_SizeDelta.y
@@ -4684,11 +4669,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -4738,7 +4723,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMin.x
@@ -4746,11 +4731,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 0
+      value: 250
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_SizeDelta.y
@@ -4786,11 +4771,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 125
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -125
       objectReference: {fileID: 0}
     - target: {fileID: 6252264846742488137, guid: 814bcc588eda3914ab104d1c06491bc8, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Thirdweb/Examples/Prefabs/Prefab_ConnectWalletNative.prefab
+++ b/Assets/Thirdweb/Examples/Prefabs/Prefab_ConnectWalletNative.prefab
@@ -222,141 +222,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &729084455826867773
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1951814203371205318}
-  - component: {fileID: 4050659555749141618}
-  - component: {fileID: 4332930428084238980}
-  m_Layer: 5
-  m_Name: Text_DeviceWallet
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1951814203371205318
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 729084455826867773}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 492210582766907308}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 65, y: 0}
-  m_SizeDelta: {x: 225, y: 60}
-  m_Pivot: {x: 0, y: 0.5}
---- !u!222 &4050659555749141618
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 729084455826867773}
-  m_CullTransparentMesh: 1
---- !u!114 &4332930428084238980
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 729084455826867773}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "Device Wallet \n(No Password)"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4293585384
-  m_fontColor: {r: 0.9098039, g: 0.9137255, b: 0.91764706, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 25
-  m_fontSizeBase: 24
-  m_fontWeight: 400
-  m_enableAutoSizing: 1
-  m_fontSizeMin: 18
-  m_fontSizeMax: 25
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &975656693657563812
 GameObject:
   m_ObjectHideFlags: 0
@@ -1181,129 +1046,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &2399674022658375376
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 492210582766907308}
-  - component: {fileID: 563741399953575813}
-  - component: {fileID: 2515914313505089090}
-  - component: {fileID: 7851835104483634769}
-  m_Layer: 5
-  m_Name: Button_DeviceWalletNoPassword
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &492210582766907308
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2399674022658375376}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3701291767386178460}
-  - {fileID: 1951814203371205318}
-  m_Father: {fileID: 8534970400187138540}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -100}
-  m_SizeDelta: {x: 290, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &563741399953575813
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2399674022658375376}
-  m_CullTransparentMesh: 1
---- !u!114 &2515914313505089090
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2399674022658375376}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.05882353, g: 0.07450981, b: 0.09411765, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &7851835104483634769
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2399674022658375376}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.105882354, g: 0.12941177, b: 0.16078432, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 2515914313505089090}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &2834748198002270219
 GameObject:
   m_ObjectHideFlags: 0
@@ -1821,7 +1563,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5630356542929988404
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2547,82 +2289,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5528720922570949588}
   m_CullTransparentMesh: 1
---- !u!1 &5602377785964225450
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3701291767386178460}
-  - component: {fileID: 4398299663579586693}
-  - component: {fileID: 8784344229235397450}
-  m_Layer: 5
-  m_Name: Image_DeviceWallet
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &3701291767386178460
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5602377785964225450}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 492210582766907308}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 10, y: 0}
-  m_SizeDelta: {x: 40, y: 40}
-  m_Pivot: {x: 0, y: 0.5}
---- !u!222 &4398299663579586693
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5602377785964225450}
-  m_CullTransparentMesh: 1
---- !u!114 &8784344229235397450
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5602377785964225450}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: db8ba9cab203b1e459eceb66e03f1106, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5813888492721473918
 GameObject:
   m_ObjectHideFlags: 0
@@ -3156,12 +2822,12 @@ RectTransform:
   - {fileID: 7276129281116852006}
   - {fileID: 7276129279747600631}
   m_Father: {fileID: 8534970400187138540}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -165}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7276129279946335586
 CanvasRenderer:
@@ -3536,7 +3202,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7276129281067027362
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4150,7 +3816,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 24e8599416c12384e9a6139addf4ca26, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  supportedWallets: 000000000100000002000000
+  supportedWallets: 0500000002000000
   OnConnectedCallback:
     m_PersistentCalls:
       m_Calls: []
@@ -4166,11 +3832,8 @@ MonoBehaviour:
   connectButton: {fileID: 8534970400764050317}
   connectDropdown: {fileID: 8534970400187138541}
   walletButtons:
-  - wallet: 0
+  - wallet: 5
     walletButton: {fileID: 8534970399124805823}
-    icon: {fileID: 21300000, guid: db8ba9cab203b1e459eceb66e03f1106, type: 3}
-  - wallet: 1
-    walletButton: {fileID: 7851835104483634769}
     icon: {fileID: 21300000, guid: db8ba9cab203b1e459eceb66e03f1106, type: 3}
   - wallet: 2
     walletButton: {fileID: 7276129279946335584}
@@ -4772,7 +4435,7 @@ GameObject:
   - component: {fileID: 8534970399124805822}
   - component: {fileID: 8534970399124805823}
   m_Layer: 5
-  m_Name: Button_DeviceWallet
+  m_Name: Button_LocalWallet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4795,10 +4458,10 @@ RectTransform:
   m_Father: {fileID: 8534970400187138540}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -35}
-  m_SizeDelta: {x: 290, y: 60}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8534970399124805821
 CanvasRenderer:
@@ -4894,7 +4557,7 @@ GameObject:
   - component: {fileID: 8534970399212253025}
   - component: {fileID: 8534970399212253026}
   m_Layer: 5
-  m_Name: Text_DeviceWallet
+  m_Name: Text_LocalWallet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4948,7 +4611,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Device Wallet
+  m_text: Local Wallet
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -5029,7 +4692,7 @@ GameObject:
   - component: {fileID: 8534970399854751769}
   - component: {fileID: 8534970399854751770}
   m_Layer: 5
-  m_Name: Image_DeviceWallet
+  m_Name: Image_LocalWallet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5127,7 +4790,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8534970399124805816}
-  - {fileID: 492210582766907308}
   - {fileID: 7276129279946335585}
   m_Father: {fileID: 8534970400764050316}
   m_RootOrder: 1
@@ -5135,7 +4797,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -25, y: -75}
-  m_SizeDelta: {x: 50, y: 200}
+  m_SizeDelta: {x: 50, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &8534970400187138528
 CanvasRenderer:
@@ -5248,7 +4910,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &8534970400764050316
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Thirdweb/Examples/Scenes/Scene_Prefabs.unity
+++ b/Assets/Thirdweb/Examples/Scenes/Scene_Prefabs.unity
@@ -1355,50 +1355,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: 'Prefab_ConnectWallet '
       objectReference: {fileID: 0}
-    - target: {fileID: 869323735247564608, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 869323735247564608, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 869323735247564608, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 869323735247564608, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 869323735247564608, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5263241086014312978, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5617547850687684258, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5617547850687684258, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5617547850687684258, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5617547850687684258, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5617547850687684258, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6539300962087038060, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
       propertyPath: m_Pivot.x
       value: 1
@@ -1481,26 +1437,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6539300962087038060, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8438017473816786819, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8438017473816786819, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8438017473816786819, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8438017473816786819, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8438017473816786819, guid: a6218c0a90161f349bc6bc87fbc624da, type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1836,46 +1772,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 574059470}
     m_Modifications:
-    - target: {fileID: 1782919512759592407, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1782919512759592407, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1782919512759592407, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1782919512759592407, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1782919512759592407, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1809789802022172611, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1809789802022172611, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1809789802022172611, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1809789802022172611, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1809789802022172611, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4483969581313638441, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -1960,33 +1856,53 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5148122847268743721, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+    - target: {fileID: 7276129279946335585, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5148122847268743721, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+    - target: {fileID: 7276129279946335585, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5148122847268743721, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+    - target: {fileID: 7276129279946335585, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5148122847268743721, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+    - target: {fileID: 7276129279946335585, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5148122847268743721, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+    - target: {fileID: 7276129279946335585, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7276129280455848231, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
-      propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7877806352732901850, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
       propertyPath: m_Name
       value: Prefab_ConnectWalletNative
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534970399124805816, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534970399124805816, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534970399124805816, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534970399124805816, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534970399124805816, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8534970400187138540, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5970370bfc0e0d5468d98e62e7ad038d, type: 3}

--- a/Assets/Thirdweb/Examples/Scripts/Prefabs/ThirdwebManager.cs
+++ b/Assets/Thirdweb/Examples/Scripts/Prefabs/ThirdwebManager.cs
@@ -25,7 +25,7 @@ public class ThirdwebManager : MonoBehaviour
 
     [Header("CHAIN DATA")]
     [Tooltip("Support any chain by adding it to this list from the inspector")]
-    public List<ChainData> supportedChainData = new List<ChainData>()
+    public List<ChainData> supportedChains = new List<ChainData>()
     {
         new ChainData("ethereum", "1", null),
         new ChainData("goerli", "5", null),
@@ -68,7 +68,7 @@ public class ThirdwebManager : MonoBehaviour
 
     public ThirdwebSDK SDK;
 
-    public static ThirdwebManager Instance;
+    public static ThirdwebManager Instance { get; private set; }
 
     private void Awake()
     {
@@ -159,12 +159,17 @@ public class ThirdwebManager : MonoBehaviour
 
     public ChainData GetChainData(string chainIdentifier)
     {
-        return supportedChainData.Find(x => x.identifier == chainIdentifier);
+        return supportedChains.Find(x => x.identifier == chainIdentifier);
     }
 
     public ChainData GetCurrentChainData()
     {
-        return supportedChainData.Find(x => x.identifier == chain);
+        return supportedChains.Find(x => x.identifier == chain);
+    }
+
+    public int GetCurrentChainID()
+    {
+        return int.Parse(GetCurrentChainData().chainId);
     }
 
     public string GetCurrentChainIdentifier()

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -136,7 +136,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 2.0.4
+  bundleVersion: 2.0.6
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
Move to WalletConnection class with a constructor and optional params to simplify api.
Move WalletProvider to an enum which is converted to a camelCase string for current bridge compatibility.
Use ThirdwebManager to figure out supported networks / if switching networks is allowed in WebGL.
