### PR TITLE
Firekeeper/stability

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Contract.cs
+++ b/Assets/Thirdweb/Core/Scripts/Contract.cs
@@ -44,7 +44,8 @@ namespace Thirdweb
         /// </summary>
         public Events events;
 
-        public Contract(string chain, string address, string abi = null) : base(abi != null ? $"{address}{Routable.subSeparator}{abi}" : address)
+        public Contract(string chain, string address, string abi = null)
+            : base(abi != null ? $"{address}{Routable.subSeparator}{abi}" : address)
         {
             this.chain = chain;
             this.address = address;
@@ -65,7 +66,7 @@ namespace Thirdweb
             }
             else
             {
-                BigInteger balance = await ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetBalance.SendRequestAsync(address);
+                BigInteger balance = await ThirdwebManager.Instance.SDK.session.Web3.Eth.GetBalance.SendRequestAsync(address);
                 CurrencyValue cv = new CurrencyValue();
                 cv.value = balance.ToString();
                 cv.displayValue = balance.ToString().ToEth();
@@ -90,7 +91,7 @@ namespace Thirdweb
                 if (this.abi == null)
                     throw new UnityException("You must pass an ABI for native platform custom calls");
 
-                var contract = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetContract(this.abi, this.address);
+                var contract = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetContract(this.abi, this.address);
                 var function = contract.GetFunction(functionName);
                 return await function.CallAsync<T>(args);
             }
@@ -126,7 +127,7 @@ namespace Thirdweb
                 if (this.abi == null)
                     throw new UnityException("You must pass an ABI for native platform custom calls");
 
-                var contract = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetContract(this.abi, this.address);
+                var contract = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetContract(this.abi, this.address);
 
                 var function = contract.GetFunction(functionName);
 

--- a/Assets/Thirdweb/Core/Scripts/Deployer.cs
+++ b/Assets/Thirdweb/Core/Scripts/Deployer.cs
@@ -37,9 +37,9 @@ namespace Thirdweb
                 throw new UnityException("This functionality is not yet available on your current platform.");
 
                 var deploymentMessage = new DropERC721Deployment();
-                var deploymentHandler = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetContractDeploymentHandler<DropERC721Deployment>();
+                var deploymentHandler = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetContractDeploymentHandler<DropERC721Deployment>();
                 var deploymentReceipt = await deploymentHandler.SendRequestAndWaitForReceiptAsync(deploymentMessage);
-                DropERC721Service dropERC721Service = new DropERC721Service(ThirdwebManager.Instance.SDK.nativeSession.web3, deploymentReceipt.ContractAddress);
+                DropERC721Service dropERC721Service = new DropERC721Service(ThirdwebManager.Instance.SDK.session.Web3, deploymentReceipt.ContractAddress);
                 var initializeReceipt = await dropERC721Service.InitializeRequestAndWaitForReceiptAsync(
                     defaultAdmin: await ThirdwebManager.Instance.SDK.wallet.GetAddress(),
                     name: metadata.name,

--- a/Assets/Thirdweb/Core/Scripts/ERC20.cs
+++ b/Assets/Thirdweb/Core/Scripts/ERC20.cs
@@ -488,8 +488,10 @@ namespace Thirdweb
                     Uid = payloadToSign.uid.HexStringToByteArray()
                 };
 
+                var name = await TransactionManager.ThirdwebRead<TokenERC20Contract.NameFunction, TokenERC20Contract.NameOutputDTO>(contractAddress, new TokenERC20Contract.NameFunction() { });
+
                 string signature = await Thirdweb.EIP712.GenerateSignature_TokenERC20(
-                    "TokenERC20",
+                    name.ReturnValue1,
                     "1",
                     await ThirdwebManager.Instance.SDK.wallet.GetChainId(),
                     contractAddress,

--- a/Assets/Thirdweb/Core/Scripts/Marketplace.cs
+++ b/Assets/Thirdweb/Core/Scripts/Marketplace.cs
@@ -905,7 +905,7 @@ namespace Thirdweb
                             AssetContract = input.assetContractAddress,
                             TokenId = BigInteger.Parse(input.tokenId),
                             Quantity = BigInteger.Parse(input.quantity ?? "1"),
-                            Currency = input.currencyContractAddress ?? Utils.GetNativeTokenWrapper(ThirdwebManager.Instance.SDK.nativeSession.lastChainId),
+                            Currency = input.currencyContractAddress ?? Utils.GetNativeTokenWrapper(ThirdwebManager.Instance.SDK.session.ChainId),
                             TotalPrice = BigInteger.Parse(input.totalPrice.ToWei()),
                             ExpirationTimestamp = (BigInteger)(input.endTimestamp ?? Utils.GetUnixTimeStampIn10Years())
                         }

--- a/Assets/Thirdweb/Core/Scripts/Multicall.cs
+++ b/Assets/Thirdweb/Core/Scripts/Multicall.cs
@@ -38,7 +38,7 @@ namespace Thirdweb
 
         public static async Task<List<TokenData721>> GetAllOwners721(string contractAddress, int startTokenId, int endTokenId)
         {
-            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetMultiQueryHandler();
+            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetMultiQueryHandler();
             var calls = new List<MulticallInputOutput<TokenERC721.OwnerOfFunction, TokenERC721.OwnerOfOutputDTO>>();
             for (int i = startTokenId; i <= endTokenId; i++)
             {
@@ -61,7 +61,7 @@ namespace Thirdweb
 
         public static async Task<List<TokenData721>> GetSpecificOwners721(string contractAddress, int[] tokenIds)
         {
-            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetMultiQueryHandler();
+            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetMultiQueryHandler();
             var calls = new List<MulticallInputOutput<TokenERC721.OwnerOfFunction, TokenERC721.OwnerOfOutputDTO>>();
             for (int i = 0; i < tokenIds.Length; i++)
             {
@@ -84,7 +84,7 @@ namespace Thirdweb
 
         public static async Task<List<TokenData721>> GetAllTokenUris721(string contractAddress, int startTokenId, int endTokenId)
         {
-            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetMultiQueryHandler();
+            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetMultiQueryHandler();
             var calls = new List<MulticallInputOutput<TokenERC721.TokenURIFunction, TokenERC721.TokenURIOutputDTO>>();
             for (int i = startTokenId; i <= endTokenId; i++)
             {
@@ -107,7 +107,7 @@ namespace Thirdweb
 
         public static async Task<List<TokenData721>> GetSpecificTokenUris721(string contractAddress, int[] tokenIds)
         {
-            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetMultiQueryHandler();
+            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetMultiQueryHandler();
             var calls = new List<MulticallInputOutput<TokenERC721.TokenURIFunction, TokenERC721.TokenURIOutputDTO>>();
             for (int i = 0; i < tokenIds.Length; i++)
             {
@@ -130,7 +130,7 @@ namespace Thirdweb
 
         public static async Task<List<int>> GetOwnedTokenIds721(string contractAddress, string ownerAddress)
         {
-            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.GetMultiQueryHandler();
+            MultiQueryHandler multiqueryHandler = ThirdwebManager.Instance.SDK.session.Web3.Eth.GetMultiQueryHandler();
             var contract = ThirdwebManager.Instance.SDK.GetContract(contractAddress);
             var balance = BigInteger.Parse(await contract.ERC721.BalanceOf(ownerAddress));
             var calls = new List<MulticallInputOutput<TokenERC721.TokenOfOwnerByIndexFunction, TokenERC721.TokenOfOwnerByIndexOutputDTO>>();

--- a/Assets/Thirdweb/Core/Scripts/ThirdwebInterceptor.cs
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebInterceptor.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MetaMask.Unity;
+using Nethereum.JsonRpc.Client;
+using Newtonsoft.Json;
+
+namespace Thirdweb
+{
+    public class ThirdwebInterceptor : RequestInterceptor
+    {
+        private readonly ThirdwebSession _thirdwebSession;
+
+        public ThirdwebInterceptor(ThirdwebSession thirdwebSession)
+        {
+            _thirdwebSession = thirdwebSession;
+        }
+
+        public override async Task<object> InterceptSendRequestAsync<T>(Func<RpcRequest, string, Task<T>> interceptedSendRequestAsync, RpcRequest request, string route = null)
+        {
+            if (request.Method == "eth_accounts" && _thirdwebSession.IsConnected)
+            {
+                return await _thirdwebSession.GetAddress().ConfigureAwait(false);
+            }
+
+            return await interceptedSendRequestAsync(request, route).ConfigureAwait(false);
+        }
+
+        public override async Task<object> InterceptSendRequestAsync<T>(
+            Func<string, string, object[], Task<T>> interceptedSendRequestAsync,
+            string method,
+            string route = null,
+            params object[] paramList
+        )
+        {
+            if (method == "eth_accounts")
+            {
+                return await _thirdwebSession.GetAddress().ConfigureAwait(false);
+            }
+
+            return await interceptedSendRequestAsync(method, route, paramList).ConfigureAwait(false);
+        }
+    }
+}

--- a/Assets/Thirdweb/Core/Scripts/ThirdwebInterceptor.cs.meta
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebInterceptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4751464e13d1c443a0b6eb9a37ec745
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Thirdweb/Core/Scripts/ThirdwebSDK.cs
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebSDK.cs
@@ -108,31 +108,7 @@ namespace Thirdweb
 
         public Storage storage;
 
-        public EthChainData currentChainData;
-
-        public class NativeSession
-        {
-            public WalletProvider provider = WalletProvider.LocalWallet;
-            public int lastChainId = -1;
-            public string lastRPC = null;
-            public Account account = null;
-            public Web3 web3 = null;
-            public Options options = new Options();
-            public SiweMessageService siweSession = new SiweMessageService();
-
-            public NativeSession(WalletProvider provider, int lastChainId, string lastRPC, Account account, Web3 web3, Options options, SiweMessageService siweSession)
-            {
-                this.provider = provider;
-                this.lastChainId = lastChainId;
-                this.lastRPC = lastRPC;
-                this.account = account;
-                this.web3 = web3;
-                this.options = options;
-                this.siweSession = siweSession;
-            }
-        }
-
-        public NativeSession nativeSession;
+        public ThirdwebSession session;
 
         /// <summary>
         /// Create an instance of the thirdweb SDK. Requires a webGL browser context.
@@ -146,28 +122,16 @@ namespace Thirdweb
             this.deployer = new Deployer();
             this.storage = new Storage(options.storage);
 
-            if (!Utils.IsWebGLBuild())
+            if (Utils.IsWebGLBuild())
             {
-                if (chainId == -1)
-                    throw new UnityException("Chain ID override required for native platforms!");
-
-                string rpc = !chainOrRPC.StartsWith("https://") ? $"https://{chainOrRPC}.rpc.thirdweb.com/339d65590ba0fa79e4c8be0af33d64eda709e13652acb02c6be63f5a1fbef9c3" : chainOrRPC;
-                nativeSession = new NativeSession(WalletProvider.LocalWallet, chainId, rpc, null, new Web3(rpc), options, new SiweMessageService());
-                // Set default WalletOptions
-                nativeSession.options.wallet = new WalletOptions()
-                {
-                    appName = options.wallet?.appName ?? "Thirdweb Game",
-                    appDescription = options.wallet?.appDescription ?? "Thirdweb Game Demo",
-                    appIcons = options.wallet?.appIcons ?? new string[] { "https://thirdweb.com/favicon.ico" },
-                    appUrl = options.wallet?.appUrl ?? "https://thirdweb.com",
-                    magicLinkApiKey = options.wallet?.magicLinkApiKey,
-                };
-
-                FetchChainData();
+                Bridge.Initialize(chainOrRPC, options);
             }
             else
             {
-                Bridge.Initialize(chainOrRPC, options);
+                if (chainId == -1)
+                    throw new UnityException("Chain ID override required for native platforms!");
+                string rpc = !chainOrRPC.StartsWith("https://") ? $"https://{chainOrRPC}.rpc.thirdweb.com/339d65590ba0fa79e4c8be0af33d64eda709e13652acb02c6be63f5a1fbef9c3" : chainOrRPC;
+                this.session = new ThirdwebSession(options, chainId, rpc);
             }
         }
 
@@ -180,72 +144,6 @@ namespace Thirdweb
         public Contract GetContract(string address, string abi = null)
         {
             return new Contract(this.chainOrRPC, address, abi);
-        }
-
-        void FetchChainData()
-        {
-            var allChainsJson = (TextAsset)Resources.Load("all_chains", typeof(TextAsset));
-            // Get networks from chainidnetwork
-            List<ChainIDNetworkData> allNetworkData = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ChainIDNetworkData>>(allChainsJson.text);
-            // Get current network
-            ChainIDNetworkData currentNetwork = allNetworkData.Find(x => x.chainId == nativeSession.lastChainId.ToString());
-            // Get block explorer urls
-            List<string> explorerUrls = new List<string>();
-            foreach (var explorer in currentNetwork.explorers)
-                explorerUrls.Add(explorer.url);
-            if (explorerUrls.Count == 0)
-                explorerUrls.Add("https://etherscan.io");
-            // Add chain
-            currentChainData = new EthChainData()
-            {
-                chainId = BigInteger.Parse(currentNetwork.chainId).ToHex(false, true) ?? BigInteger.Parse(nativeSession.lastChainId.ToString()).ToHex(false, true),
-                blockExplorerUrls = explorerUrls.ToArray(),
-                chainName = currentNetwork.name ?? ThirdwebManager.Instance.GetCurrentChainIdentifier(),
-                iconUrls = new string[] { "ipfs://QmdwQDr6vmBtXmK2TmknkEuZNoaDqTasFdZdu3DRw8b2wt" },
-                nativeCurrency = new NativeCurrency()
-                {
-                    name = currentNetwork.nativeCurrency?.name ?? "Ether",
-                    symbol = currentNetwork.nativeCurrency?.symbol ?? "ETH",
-                    decimals = int.Parse(currentNetwork.nativeCurrency?.decimals ?? "18")
-                },
-                rpcUrls = new string[] { nativeSession.lastRPC }
-            };
-        }
-
-        [System.Serializable]
-        public class ChainIDNetworkData
-        {
-            public string name;
-            public string chain;
-            public string icon;
-            public List<string> rpc;
-            public ChainIDNetworkNativeCurrency nativeCurrency;
-            public string chainId;
-            public List<ChainIDNetworkExplorer> explorers;
-        }
-
-        [System.Serializable]
-        public class ChainIDNetworkNativeCurrency
-        {
-            public string name;
-            public string symbol;
-            public string decimals;
-        }
-
-        [System.Serializable]
-        public class ChainIDNetworkExplorer
-        {
-            public string name;
-            public string url;
-            public string standard;
-        }
-
-        public struct ChaiNIDNetworkIcon
-        {
-            public string url;
-            public int width;
-            public int height;
-            public string format;
         }
     }
 }

--- a/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using link.magic.unity.sdk;
+using MetaMask.NEthereum;
+using MetaMask.Unity;
+using Nethereum.Hex.HexConvertors.Extensions;
+using Nethereum.Hex.HexTypes;
+using Nethereum.JsonRpc.Client;
+using Nethereum.RPC.Eth;
+using Nethereum.Siwe;
+using Nethereum.Web3;
+using Nethereum.Web3.Accounts;
+using Newtonsoft.Json;
+using UnityEngine;
+using WalletConnectSharp.Core.Models.Ethereum;
+using WalletConnectSharp.NEthereum;
+using WalletConnectSharp.NEthereum.Client;
+using WalletConnectSharp.Unity;
+
+namespace Thirdweb
+{
+    public class ThirdwebSession
+    {
+        #region Properties
+
+        public ThirdwebSDK.Options Options { get; private set; }
+        public int ChainId { get; private set; }
+        public string RPC { get; private set; }
+        public SiweMessageService SiweSession { get; private set; }
+        public Web3 Web3 { get; private set; }
+        public WalletProvider WalletProvider { get; private set; }
+        public Account LocalAccount { get; private set; }
+        public Account PersonalAccount { get; private set; }
+        public string Email { get; private set; }
+        public ThirdwebChainData CurrentChainData { get; private set; }
+        public ThirdwebInterceptor Interceptor { get; private set; }
+
+        public bool IsConnected
+        {
+            get { return LocalAccount != null || ThirdwebManager.Instance.SDK.session.WalletProvider != WalletProvider.LocalWallet; }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        public ThirdwebSession(ThirdwebSDK.Options options, int chainId, string rpcUrl)
+        {
+            Options = options;
+            ChainId = chainId;
+            RPC = rpcUrl;
+            SiweSession = new SiweMessageService();
+            Web3 = new Web3(rpcUrl);
+            WalletProvider = WalletProvider.LocalWallet;
+            LocalAccount = null;
+            PersonalAccount = null;
+            Email = null;
+            Interceptor = null;
+            CurrentChainData = FetchChainData();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public async Task<string> Connect(WalletProvider walletProvider, string email = null, string password = null)
+        {
+            WalletProvider = walletProvider;
+            Email = email;
+
+            switch (walletProvider)
+            {
+                case WalletProvider.LocalWallet:
+                    InitializeLocalWallet(password);
+                    break;
+                case WalletProvider.WalletConnectV1:
+                    await InitializeWalletConnect();
+                    break;
+                case WalletProvider.MagicLink:
+                    await InitializeMagicLink();
+                    break;
+                case WalletProvider.MetaMask:
+                    await InitializeMetaMask();
+                    break;
+                default:
+                    throw new UnityException("This wallet connection method is not supported on this platform!");
+            }
+
+            Interceptor = new ThirdwebInterceptor(this);
+            Web3.Client.OverridingRequestInterceptor = Interceptor;
+
+            try
+            {
+                await SwitchNetwork(new ThirdwebChain() { chainId = CurrentChainData.chainId });
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning("Switching chain error, attempting to add chain: " + e.Message);
+                try
+                {
+                    await AddNetwork(CurrentChainData);
+                    await SwitchNetwork(new ThirdwebChain() { chainId = CurrentChainData.chainId });
+                }
+                catch (System.Exception f)
+                {
+                    Debug.LogWarning("Adding chain error: " + f.Message);
+                }
+            }
+
+            return await GetAddress();
+        }
+
+        public void Disconnect()
+        {
+            switch (WalletProvider)
+            {
+                case WalletProvider.WalletConnectV1:
+                    WalletConnect.Instance.DisableWalletConnect();
+                    break;
+                case WalletProvider.MagicLink:
+                    MagicUnity.Instance.DisableMagicAuth();
+                    break;
+                case WalletProvider.MetaMask:
+                    MetaMaskUnity.Instance.Wallet.Disconnect();
+                    break;
+                default:
+                    break;
+            }
+
+            ThirdwebManager.Instance.SDK.session = new ThirdwebSession(Options, ChainId, RPC);
+        }
+
+        public async Task<string> GetAddress()
+        {
+            string address = null;
+            switch (WalletProvider)
+            {
+                case WalletProvider.LocalWallet:
+                    if (LocalAccount == null)
+                        throw new UnityException("No Account Connected!");
+                    address = LocalAccount.Address;
+                    break;
+                case WalletProvider.WalletConnectV1:
+                    address = WalletConnect.Instance.Session.Accounts[0];
+                    break;
+                case WalletProvider.MagicLink:
+                    address = await MagicUnity.Instance.GetAddress();
+                    break;
+                case WalletProvider.MetaMask:
+                    address = MetaMaskUnity.Instance.Wallet.SelectedAddress;
+                    break;
+                default:
+                    throw new UnityException("No Account Connected!");
+            }
+            return Nethereum.Util.AddressUtil.Current.ConvertToChecksumAddress(address);
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private async Task SwitchNetwork(ThirdwebChain newChain)
+        {
+            Debug.Log("Switching to chain: " + newChain.chainId);
+            var request = new RpcRequest(new Guid().ToString(), "wallet_switchEthereumChain", new object[] { newChain });
+            CurrentChainData.chainId = newChain.chainId;
+            await Web3.Client.SendRequestAsync(request);
+        }
+
+        private async Task AddNetwork(ThirdwebChainData newChainData)
+        {
+            var request = new RpcRequest(new Guid().ToString(), "wallet_addEthereumChain", new object[] { newChainData });
+            CurrentChainData = newChainData;
+            await Web3.Client.SendRequestAsync(request);
+        }
+
+        private void InitializeLocalWallet(string password)
+        {
+            LocalAccount = Utils.UnlockOrGenerateLocalAccount(ChainId, password);
+            Web3 = new Web3(LocalAccount, RPC);
+            PersonalAccount = null;
+        }
+
+        private async Task InitializeWalletConnect()
+        {
+            if (WalletConnect.Instance == null)
+            {
+                GameObject.Instantiate(ThirdwebManager.Instance.WalletConnectPrefab);
+                await new WaitForSeconds(0.5f);
+            }
+
+            WalletConnect.Instance.Initialize();
+            await WalletConnect.Instance.EnableWalletConnect();
+            Web3 = new Web3(new WalletConnectClient(WalletConnect.Instance.Session));
+            LocalAccount = null;
+            PersonalAccount = null;
+        }
+
+        private async Task InitializeMagicLink()
+        {
+            if (MagicUnity.Instance == null)
+            {
+                GameObject.Instantiate(ThirdwebManager.Instance.MagicAuthPrefab);
+                await new WaitForSeconds(0.5f);
+            }
+
+            if (Options.wallet?.magicLinkApiKey == null)
+                throw new UnityException("MagicLink API Key is not set!");
+
+            MagicUnity.Instance.Initialize(Options.wallet?.magicLinkApiKey, new link.magic.unity.sdk.Relayer.CustomNodeConfiguration(RPC, ChainId));
+            await MagicUnity.Instance.EnableMagicAuth(Email);
+            Web3 = new Web3(Magic.Instance.Provider);
+            LocalAccount = null;
+            PersonalAccount = null;
+        }
+
+        private async Task InitializeMetaMask()
+        {
+            if (MetaMaskUnity.Instance == null)
+            {
+                GameObject.Instantiate(ThirdwebManager.Instance.MetamaskPrefab);
+                MetaMaskUnity.Instance.Initialize();
+                await new WaitForSeconds(1f);
+            }
+
+            MetaMaskUnity.Instance.Connect();
+            bool connected = false;
+            MetaMaskUnity.Instance.Wallet.WalletAuthorized += (sender, e) =>
+            {
+                Web3 = MetaMaskUnity.Instance.Wallet.CreateWeb3();
+                LocalAccount = null;
+                PersonalAccount = null;
+                connected = true;
+            };
+            await new WaitUntil(() => connected);
+        }
+
+        private ThirdwebChainData FetchChainData()
+        {
+            var allChainsJson = (TextAsset)Resources.Load("all_chains", typeof(TextAsset));
+
+            List<ChainIDNetworkData> allNetworkData = Newtonsoft.Json.JsonConvert.DeserializeObject<List<ChainIDNetworkData>>(allChainsJson.text);
+
+            ChainIDNetworkData currentNetwork = allNetworkData.Find(x => x.chainId == ChainId.ToString());
+
+            List<string> explorerUrls = new List<string>();
+            foreach (var explorer in currentNetwork.explorers)
+                explorerUrls.Add(explorer.url);
+            if (explorerUrls.Count == 0)
+                explorerUrls.Add("https://etherscan.io");
+
+            return new ThirdwebChainData()
+            {
+                chainId = BigInteger.Parse(currentNetwork.chainId).ToHex(false, true) ?? BigInteger.Parse(ChainId.ToString()).ToHex(false, true),
+                blockExplorerUrls = explorerUrls.ToArray(),
+                chainName = currentNetwork.name ?? ThirdwebManager.Instance.GetCurrentChainIdentifier(),
+                iconUrls = new string[] { "ipfs://QmdwQDr6vmBtXmK2TmknkEuZNoaDqTasFdZdu3DRw8b2wt" },
+                nativeCurrency = new NativeCurrency()
+                {
+                    name = currentNetwork.nativeCurrency?.name ?? "Ether",
+                    symbol = currentNetwork.nativeCurrency?.symbol ?? "ETH",
+                    decimals = int.Parse(currentNetwork.nativeCurrency?.decimals ?? "18")
+                },
+                rpcUrls = new string[] { RPC }
+            };
+        }
+
+        #endregion
+
+        #region Nested Classes
+
+        public class ThirdwebChainData : ThirdwebChain
+        {
+            public string[] blockExplorerUrls;
+            public string chainName;
+            public string[] iconUrls;
+            public NativeCurrency nativeCurrency;
+            public string[] rpcUrls;
+        }
+
+        public class ThirdwebChain
+        {
+            public string chainId;
+        }
+
+        [System.Serializable]
+        public class ChainIDNetworkData
+        {
+            public string name;
+            public string chain;
+            public string icon;
+            public List<string> rpc;
+            public ChainIDNetworkNativeCurrency nativeCurrency;
+            public string chainId;
+            public List<ChainIDNetworkExplorer> explorers;
+        }
+
+        [System.Serializable]
+        public class ChainIDNetworkNativeCurrency
+        {
+            public string name;
+            public string symbol;
+            public string decimals;
+        }
+
+        [System.Serializable]
+        public class ChainIDNetworkExplorer
+        {
+            public string name;
+            public string url;
+            public string standard;
+        }
+
+        public struct ChaiNIDNetworkIcon
+        {
+            public string url;
+            public int width;
+            public int height;
+            public string format;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs
@@ -157,23 +157,26 @@ namespace Thirdweb
             return Nethereum.Util.AddressUtil.Current.ConvertToChecksumAddress(address);
         }
 
+        public async Task<T> Request<T>(string method, params object[] parameters)
+        {
+            var request = new RpcRequest(new Guid().ToString(), method, parameters);
+            return await Web3.Client.SendRequestAsync<T>(request);
+        }
+
         #endregion
 
         #region Private Methods
 
         private async Task SwitchNetwork(ThirdwebChain newChain)
         {
-            Debug.Log("Switching to chain: " + newChain.chainId);
-            var request = new RpcRequest(new Guid().ToString(), "wallet_switchEthereumChain", new object[] { newChain });
+            await Request<object>("wallet_switchEthereumChain", new object[] { newChain });
             CurrentChainData.chainId = newChain.chainId;
-            await Web3.Client.SendRequestAsync(request);
         }
 
         private async Task AddNetwork(ThirdwebChainData newChainData)
         {
-            var request = new RpcRequest(new Guid().ToString(), "wallet_addEthereumChain", new object[] { newChainData });
+            await Request<object>("wallet_addEthereumChain", new object[] { newChainData });
             CurrentChainData = newChainData;
-            await Web3.Client.SendRequestAsync(request);
         }
 
         private void InitializeLocalWallet(string password)

--- a/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs.meta
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15aaced52c60c234f91d10bd86beceb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Thirdweb/Core/Scripts/Types.cs
+++ b/Assets/Thirdweb/Core/Scripts/Types.cs
@@ -388,6 +388,16 @@ namespace Thirdweb
         public string gasLimit;
         public string gasPrice;
 
+        public TransactionRequest(string from, string to, string data, string value, string gasLimit, string gasPrice)
+        {
+            this.from = from;
+            this.to = to;
+            this.data = data;
+            this.value = value;
+            this.gasLimit = gasLimit;
+            this.gasPrice = gasPrice;
+        }
+
         public override string ToString()
         {
             return $"TransactionRequest:" + $"\n>from: {from}" + $"\n>to: {to}" + $"\n>data: {data}" + $"\n>value: {value}" + $"\n>gasLimit: {gasLimit}" + $"\n>gasPrice: {gasPrice}";

--- a/Assets/Thirdweb/Core/Scripts/Utils.cs
+++ b/Assets/Thirdweb/Core/Scripts/Utils.cs
@@ -246,8 +246,8 @@ namespace Thirdweb
 
         public async static Task<BigInteger> GetCurrentBlockTimeStamp()
         {
-            var blockNumber = await ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.Blocks.GetBlockNumber.SendRequestAsync();
-            var block = await ThirdwebManager.Instance.SDK.nativeSession.web3.Eth.Blocks.GetBlockWithTransactionsByNumber.SendRequestAsync(new Nethereum.Hex.HexTypes.HexBigInteger(blockNumber));
+            var blockNumber = await ThirdwebManager.Instance.SDK.session.Web3.Eth.Blocks.GetBlockNumber.SendRequestAsync();
+            var block = await ThirdwebManager.Instance.SDK.session.Web3.Eth.Blocks.GetBlockWithTransactionsByNumber.SendRequestAsync(new Nethereum.Hex.HexTypes.HexBigInteger(blockNumber));
             return block.Timestamp.Value;
         }
 
@@ -315,13 +315,29 @@ namespace Thirdweb
                         R = 1,
                         P = 8
                     };
-                    var ecKey = Nethereum.Signer.EthECKey.GenerateKey();
+                    byte[] seed = new byte[32];
+                    using (var rng = new System.Security.Cryptography.RNGCryptoServiceProvider())
+                    {
+                        rng.GetBytes(seed);
+                    }
+                    var ecKey = Nethereum.Signer.EthECKey.GenerateKey(seed);
                     var keyStore = keyStoreService.EncryptAndGenerateKeyStore(password, ecKey.GetPrivateKeyAsBytes(), ecKey.GetPublicAddress(), scryptParams);
                     var json = keyStoreService.SerializeKeyStoreToJson(keyStore);
                     File.WriteAllText(path, json);
                     return new Account(ecKey, chainId);
                 }
             }
+        }
+
+        public static Account GenerateRandomAccount(int chainId)
+        {
+            byte[] seed = new byte[32];
+            using (var rng = new System.Security.Cryptography.RNGCryptoServiceProvider())
+            {
+                rng.GetBytes(seed);
+            }
+            var ecKey = Nethereum.Signer.EthECKey.GenerateKey(seed);
+            return new Account(ecKey, chainId);
         }
 
         public static string cidToIpfsUrl(this string cid, bool useGateway = false)

--- a/Assets/Thirdweb/Core/Scripts/Wallet.cs
+++ b/Assets/Thirdweb/Core/Scripts/Wallet.cs
@@ -220,8 +220,7 @@ namespace Thirdweb
             }
             else
             {
-                var req = new RpcRequest(new Guid().ToString(), "eth_accounts", null);
-                return await ThirdwebManager.Instance.SDK.session.Web3.Client.SendRequestAsync<string>(req);
+                return await ThirdwebManager.Instance.SDK.session.Request<string>("eth_accounts");
             }
         }
 
@@ -251,7 +250,8 @@ namespace Thirdweb
             }
             else
             {
-                return ThirdwebManager.Instance.SDK.session.ChainId;
+                var hexChainId = await ThirdwebManager.Instance.SDK.session.Request<string>("eth_chainId");
+                return (int)hexChainId.HexToBigInteger(false);
             }
         }
 
@@ -312,8 +312,7 @@ namespace Thirdweb
                 }
                 else
                 {
-                    var request = new RpcRequest(new Guid().ToString(), "personal_sign", await GetAddress(), message);
-                    return await ThirdwebManager.Instance.SDK.session.Web3.Client.SendRequestAsync<string>(request);
+                    return await ThirdwebManager.Instance.SDK.session.Request<string>("personal_sign", await GetAddress(), message);
                 }
             }
         }
@@ -346,8 +345,7 @@ namespace Thirdweb
                     property.Value = property.Value.ToString();
 
                 string safeJson = jsonObject.ToString();
-                var request = new RpcRequest(new Guid().ToString(), "eth_signTypedData_v4", await GetAddress(), safeJson);
-                return await ThirdwebManager.Instance.SDK.session.Web3.Client.SendRequestAsync<string>(request);
+                return await ThirdwebManager.Instance.SDK.session.Request<string>("eth_signTypedData_v4", await GetAddress(), safeJson);
             }
         }
 
@@ -387,7 +385,7 @@ namespace Thirdweb
                     new Nethereum.Hex.HexTypes.HexBigInteger(BigInteger.Parse(transactionRequest.gasPrice)),
                     new Nethereum.Hex.HexTypes.HexBigInteger(transactionRequest.value)
                 );
-                var receipt = await ThirdwebManager.Instance.SDK.session.Web3.TransactionManager.SendTransactionAndWaitForReceiptAsync(input);
+                var receipt = await ThirdwebManager.Instance.SDK.session.Web3.Eth.TransactionManager.SendTransactionAndWaitForReceiptAsync(input);
                 return receipt.ToTransactionResult();
             }
         }

--- a/Assets/Thirdweb/Plugins/AsyncAwaitUtil/Source/Internal/AsyncCoroutineRunner.cs
+++ b/Assets/Thirdweb/Plugins/AsyncAwaitUtil/Source/Internal/AsyncCoroutineRunner.cs
@@ -16,6 +16,9 @@ namespace UnityAsyncAwaitUtil
             {
                 if (_instance == null)
                 {
+                    if (Application.isEditor && !Application.isPlaying)
+                        return null;
+
                     _instance = new GameObject("AsyncCoroutineRunner").AddComponent<AsyncCoroutineRunner>();
                 }
 

--- a/Assets/Thirdweb/Plugins/MetaMask/Plugins/Libraries/SocketIOUnity/Runtime/WebSocketDispatcher.cs
+++ b/Assets/Thirdweb/Plugins/MetaMask/Plugins/Libraries/SocketIOUnity/Runtime/WebSocketDispatcher.cs
@@ -16,6 +16,9 @@ namespace MetaMask.SocketIOClient
             {
                 if (instance == null)
                 {
+                    if (Application.isEditor && !Application.isPlaying)
+                        return null;
+
                     instance = new GameObject("WebSocket Dispatcher").AddComponent<WebSocketDispatcher>();
                 }
                 return instance;

--- a/Assets/Thirdweb/Plugins/MetaMask/Resources/MetaMask/Config/Default.asset
+++ b/Assets/Thirdweb/Plugins/MetaMask/Resources/MetaMask/Config/Default.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77f59ac8818a0fe45a3283d7576eead3, type: 3}
   m_Name: Default
   m_EditorClassIdentifier: 
-  log: 1
+  log: 0
   appName: Thirdweb Demo Game
   appUrl: thirdweb.com
   encrypt: 1

--- a/Assets/Thirdweb/Plugins/MetaMask/Runtime/MetaMaskWallet.cs
+++ b/Assets/Thirdweb/Plugins/MetaMask/Runtime/MetaMaskWallet.cs
@@ -12,33 +12,40 @@ using Newtonsoft.Json;
 
 namespace MetaMask
 {
-
     /// <summary>
     /// The main interface to interact with the MetaMask wallet.
     /// </summary>
     public class MetaMaskWallet : IDisposable
     {
-
         #region Events
 
         /// <summary>Raised when the wallet is ready.</summary>
         public event EventHandler WalletReady;
+
         /// <summary>Raised when the wallet is paused.</summary>
         public event EventHandler WalletPaused;
+
         /// <summary>Occurs when a wallet is connected.</summary>
         public event EventHandler WalletConnected;
+
         /// <summary>Occurs when a wallet is disconnected.</summary>
         public event EventHandler WalletDisconnected;
+
         /// <summary>Occurs when the chain ID is changed.</summary>
         public event EventHandler ChainIdChanged;
+
         /// <summary>Occurs when the account is changed.</summary>
         public event EventHandler AccountChanged;
+
         /// <summary>Occurs when the wallet connection is authorized by the user.</summary>
         public event EventHandler WalletAuthorized;
+
         /// <summary>Occurs when the wallet connection is unauthorized by the user.</summary>
         public event EventHandler WalletUnauthorized;
+
         /// <summary>Occurs when the Ethereum request's response received.</summary>
         public event EventHandler<MetaMaskEthereumRequestResultEventArgs> EthereumRequestResultReceived;
+
         /// <summary>Occurs when the Ethereum request has failed.</summary>
         public event EventHandler<MetaMaskEthereumRequestFailedEventArgs> EthereumRequestFailed;
 
@@ -54,14 +61,19 @@ namespace MetaMask
 
         /// <summary>The name of the event that is fired when a message is received.</summary>
         protected const string MessageEventName = "message";
-        /// <summary>The name of the event that is raised when a user joins a channel.</summary>       
+
+        /// <summary>The name of the event that is raised when a user joins a channel.</summary>
         protected const string JoinChannelEventName = "join_channel";
-        /// <summary>The name of the event that is fired when the user leaves a channel.</summary>       
+
+        /// <summary>The name of the event that is fired when the user leaves a channel.</summary>
         protected const string LeaveChannelEventName = "leave_channel";
+
         /// <summary>The name of the event that is fired when a client connects.</summary>
         protected const string ClientsConnectedEventName = "clients_connected";
+
         /// <summary>The name of the event that is raised when clients are disconnected.</summary>
         protected const string ClientsDisconnectedEventName = "clients_disconnected";
+
         /// <summary>The name of the event that is raised when clients are waiting to join.</summary>
         protected const string ClientsWaitingToJoinEventName = "clients_waiting_to_join";
 
@@ -73,7 +85,8 @@ namespace MetaMask
 
         #region Fields
         /// <summary>List of methods that should be redirected.</summary>
-        protected static List<string> MethodsToRedirect = new List<string>() {
+        protected static List<string> MethodsToRedirect = new List<string>()
+        {
             "eth_sendTransaction",
             "eth_signTransaction",
             "eth_sign",
@@ -85,28 +98,36 @@ namespace MetaMask
             "wallet_addEthereumChain",
             "wallet_switchEthereumChain"
         };
+
         /// <summary>The users wallet session.</summary>
         protected MetaMaskSession session;
+
         /// <summary>The transport used in the wallet session.</summary>
         protected IMetaMaskTransport transport;
+
         /// <summary>The socket connection used in the user wallet session.</summary>
         protected IMetaMaskSocketWrapper socket;
+
         /// <summary>The socket connection url.</summary>
         protected string socketUrl;
 
         /// <summary>Indicates whether the keys have been exchanged.</summary>
         /// <returns>True if the keys have been exchanged; otherwise, false.</returns>
         protected bool keysExchanged = false;
+
         /// <summary>The public key of the wallet.</summary>
         protected string walletPublicKey = string.Empty;
+
         /// <summary>Gets or sets the selected address.</summary>
         protected string selectedAddress = string.Empty;
+
         /// <summary>The ID of the chain that is currently selected.</summary>
         protected string selectedChainId = string.Empty;
 
         /// <summary>Indicates whether the application is connected to the Internet.</summary>
         /// <returns>True if the application is connected to the Internet; otherwise, false.</returns>
         protected bool connected = false;
+
         /// <summary>Gets or sets a value indicating whether the application is paused.</summary>
         /// <value>true if the application is paused; otherwise, false.</value>
         protected bool paused = false;
@@ -171,14 +192,8 @@ namespace MetaMask
         /// <summary>Gets or sets the analytics platform.</summary>
         public string AnalyticsPlatform
         {
-            get
-            {
-                return this.analyticsPlatform;
-            }
-            set
-            {
-                this.analyticsPlatform = value;
-            }
+            get { return this.analyticsPlatform; }
+            set { this.analyticsPlatform = value; }
         }
 
         #endregion
@@ -235,7 +250,11 @@ namespace MetaMask
             string jsonString = JsonConvert.SerializeObject(analyticsInfo);
             MetaMaskDebug.Log("Sending Analytics: " + jsonString);
 
-            var response = await this.socket.SendWebRequest(this.socketUrl.EndsWith("/") ? this.socketUrl + "debug" : this.socketUrl + "/debug", jsonString, new Dictionary<string, string> { { "Content-Type", "application/json" } });
+            var response = await this.socket.SendWebRequest(
+                this.socketUrl.EndsWith("/") ? this.socketUrl + "debug" : this.socketUrl + "/debug",
+                jsonString,
+                new Dictionary<string, string> { { "Content-Type", "application/json" } }
+            );
             if (response.IsSuccessful)
             {
                 MetaMaskDebug.Log("Analytics sent successfully!");
@@ -257,11 +276,7 @@ namespace MetaMask
                 Url = this.session.Data.AppUrl,
                 Platform = this.analyticsPlatform
             };
-            var requestInfo = new MetaMaskRequestInfo
-            {
-                Type = "originator_info",
-                OriginatorInfo = originatorInfo
-            };
+            var requestInfo = new MetaMaskRequestInfo { Type = "originator_info", OriginatorInfo = originatorInfo };
             SendMessage(requestInfo, true);
 
             var analyticsInfo = new MetaMaskAnalyticsInfo
@@ -293,18 +308,10 @@ namespace MetaMask
             InitializeState();
 
             this.connectionTcs = new TaskCompletionSource<JsonElement>();
-            var request = new MetaMaskEthereumRequest
-            {
-                Method = "eth_requestAccounts",
-                Parameters = new string[] { }
-            };
+            var request = new MetaMaskEthereumRequest { Method = "eth_requestAccounts", Parameters = new string[] { } };
             string id = Guid.NewGuid().ToString();
 
-            var submittedRequest = new MetaMaskSubmittedRequest
-            {
-                Method = request.Method,
-                Promise = this.connectionTcs
-            };
+            var submittedRequest = new MetaMaskSubmittedRequest { Method = request.Method, Promise = this.connectionTcs };
 
             this.submittedRequests.Add(id, submittedRequest);
             SendEthereumRequest(id, request, false);
@@ -322,18 +329,10 @@ namespace MetaMask
             InitializeState();
 
             this.connectionTcs = new TaskCompletionSource<JsonElement>();
-            var request = new MetaMaskEthereumRequest
-            {
-                Method = "eth_requestAccounts",
-                Parameters = new string[] { }
-            };
+            var request = new MetaMaskEthereumRequest { Method = "eth_requestAccounts", Parameters = new string[] { } };
             string id = Guid.NewGuid().ToString();
 
-            var submittedRequest = new MetaMaskSubmittedRequest
-            {
-                Method = request.Method,
-                Promise = this.connectionTcs
-            };
+            var submittedRequest = new MetaMaskSubmittedRequest { Method = request.Method, Promise = this.connectionTcs };
 
             this.submittedRequests.Add(id, submittedRequest);
             SendEthereumRequest(id, request, false);
@@ -344,11 +343,7 @@ namespace MetaMask
         /// <summary>Initialize the wallet state.</summary>
         protected void InitializeState()
         {
-            var request = new MetaMaskEthereumRequest
-            {
-                Method = "metamask_getProviderState",
-                Parameters = new string[] { }
-            };
+            var request = new MetaMaskEthereumRequest { Method = "metamask_getProviderState", Parameters = new string[] { } };
             Request(request);
         }
 
@@ -371,9 +366,7 @@ namespace MetaMask
             JoinChannel(channelId);
         }
 
-        private void OnSocketDisconnected(object sender, EventArgs e)
-        {
-        }
+        private void OnSocketDisconnected(object sender, EventArgs e) { }
 
         protected void JoinChannel(string channelId)
         {
@@ -561,7 +554,6 @@ namespace MetaMask
                 request.Promise.SetException(ex);
                 EthereumRequestFailed?.Invoke(this, new MetaMaskEthereumRequestFailedEventArgs(request, error));
             }
-
             // The request has been successful
             else if (data.TryGetProperty("result", out var result))
             {
@@ -660,7 +652,6 @@ namespace MetaMask
         /// <returns>true if the method should open the MetaMask app; otherwise, false.</returns>
         protected bool ShouldOpenMM(string method)
         {
-
             // Only open the wallet for requesting accounts when the address is not already provided.
             if (method == "eth_requestAccounts" && string.IsNullOrEmpty(this.selectedAddress))
             {
@@ -695,11 +686,7 @@ namespace MetaMask
             {
                 var tcs = new TaskCompletionSource<JsonElement>();
                 var id = Guid.NewGuid().ToString();
-                var submittedRequest = new MetaMaskSubmittedRequest()
-                {
-                    Method = request.Method,
-                    Promise = tcs
-                };
+                var submittedRequest = new MetaMaskSubmittedRequest() { Method = request.Method, Promise = tcs };
                 this.submittedRequests.Add(id, submittedRequest);
                 SendEthereumRequest(id, request, ShouldOpenMM(request.Method));
                 return tcs.Task;
@@ -713,13 +700,7 @@ namespace MetaMask
             this.connectionTcs = new TaskCompletionSource<JsonElement>();
 
             // Initialize the socket
-            this.socket.Initialize(this.socketUrl, new MetaMaskSocketOptions()
-            {
-                ExtraHeaders = new Dictionary<string, string>
-                {
-                    {"User-Agent", this.transport.UserAgent}
-                }
-            });
+            this.socket.Initialize(this.socketUrl, new MetaMaskSocketOptions() { ExtraHeaders = new Dictionary<string, string> { { "User-Agent", this.transport.UserAgent } } });
             this.socket.ConnectAsync();
 
             this.session.Data.ChannelId = Guid.NewGuid().ToString();
@@ -772,7 +753,6 @@ namespace MetaMask
         }
 
         #endregion
-
     }
 
     public class MetaMaskEthereumRequestResultEventArgs : EventArgs
@@ -804,7 +784,6 @@ namespace MetaMask
         {
             this.Request = request;
             this.Error = error;
-
         }
     }
 }

--- a/Assets/Thirdweb/Plugins/MetaMask/Scripts/MetaMaskUnity.cs
+++ b/Assets/Thirdweb/Plugins/MetaMask/Scripts/MetaMaskUnity.cs
@@ -234,11 +234,9 @@ namespace MetaMask.Unity
             }
         }
 
-        /// <summary>Makes a request to the users connected wallet.</summary>
-        /// <param name="request">The ethereum request to send to the user wallet.</param>
-        public void Request(MetaMaskEthereumRequest request)
+        public async Task<System.Text.Json.JsonElement> Request(Nethereum.JsonRpc.Client.RpcRequest request)
         {
-            this.wallet.Request(request);
+            return await this.wallet.Request(new MetaMaskEthereumRequest() { Method = request.Method, Parameters = request.RawParameters });
         }
 
         #endregion
@@ -249,37 +247,6 @@ namespace MetaMask.Unity
         protected void Release()
         {
             this.wallet.Dispose();
-        }
-
-        // Utils
-
-        public async Task<string> PersonalSign(string message)
-        {
-            var request = new MetaMaskEthereumRequest { Method = "personal_sign", Parameters = new string[] { Wallet.SelectedAddress, message } };
-            var result = await MetaMaskUnity.Instance.Wallet.Request(request);
-            return result.GetString();
-        }
-
-        public async Task<string> SignTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData)
-            where TDomain : IDomain
-        {
-            var request = new MetaMaskEthereumRequest { Method = "eth_signTypedData_v4", Parameters = new string[] { Wallet.SelectedAddress, typedData.ToJson(data) } };
-            var result = await MetaMaskUnity.Instance.Wallet.Request(request);
-            return result.GetString();
-        }
-
-        public async Task<string> WalletAddEthChain(object ethChainData)
-        {
-            var request = new MetaMaskEthereumRequest { Method = "wallet_addEthereumChain", Parameters = new object[] { ethChainData } };
-            var result = await MetaMaskUnity.Instance.Wallet.Request(request);
-            return result.GetString();
-        }
-
-        public async Task<string> WalletSwitchEthChain(object ethChain)
-        {
-            var request = new MetaMaskEthereumRequest { Method = "wallet_switchEthereumChain", Parameters = new object[] { ethChain } };
-            var result = await MetaMaskUnity.Instance.Wallet.Request(request);
-            return result.GetString();
         }
 
         #endregion

--- a/Assets/Thirdweb/Plugins/WalletConnectSharp.Unity/WalletConnect.cs
+++ b/Assets/Thirdweb/Plugins/WalletConnectSharp.Unity/WalletConnect.cs
@@ -82,7 +82,7 @@ namespace WalletConnectSharp.Unity
         public async Task<WCSessionData> EnableWalletConnect()
         {
             SetMode(true);
-            var sessionData = await Connect(ThirdwebManager.Instance.SDK.nativeSession.lastChainId);
+            var sessionData = await Connect(ThirdwebManager.Instance.SDK.session.ChainId);
             SetMode(false);
             return sessionData;
         }
@@ -170,10 +170,10 @@ namespace WalletConnectSharp.Unity
                 Session = new WalletConnectUnitySession(
                     new ClientMeta()
                     {
-                        Name = ThirdwebManager.Instance.SDK.nativeSession.options.wallet?.appName,
-                        Description = ThirdwebManager.Instance.SDK.nativeSession.options.wallet?.appDescription,
-                        URL = ThirdwebManager.Instance.SDK.nativeSession.options.wallet?.appUrl,
-                        Icons = ThirdwebManager.Instance.SDK.nativeSession.options.wallet?.appIcons,
+                        Name = ThirdwebManager.Instance.SDK.session.Options.wallet?.appName,
+                        Description = ThirdwebManager.Instance.SDK.session.Options.wallet?.appDescription,
+                        URL = ThirdwebManager.Instance.SDK.session.Options.wallet?.appUrl,
+                        Icons = ThirdwebManager.Instance.SDK.session.Options.wallet?.appIcons,
                     },
                     this,
                     null,
@@ -330,7 +330,7 @@ namespace WalletConnectSharp.Unity
             if (pauseStatus)
                 SaveSession();
             else if (PlayerPrefs.HasKey(SessionKey))
-                await Connect(ThirdwebManager.Instance.SDK.nativeSession.lastChainId);
+                await Connect(ThirdwebManager.Instance.SDK.session.ChainId);
         }
 
         private void SaveSession()
@@ -436,40 +436,6 @@ namespace WalletConnectSharp.Unity
         {
             if (PlayerPrefs.HasKey(SessionKey))
                 PlayerPrefs.DeleteKey(SessionKey);
-        }
-
-        // Utility
-
-        public async Task<string> WalletAddEthChain(EthChainData chainData)
-        {
-            var results = await Session.WalletAddEthChain(chainData);
-            return results;
-        }
-
-        public async Task<string> WalletSwitchEthChain(EthChain ethChain)
-        {
-            var results = await Session.WalletSwitchEthChain(ethChain);
-            return results;
-        }
-
-        public async Task<string> PersonalSign(string message)
-        {
-            var address = Session.Accounts[0];
-            var results = await Session.EthPersonalSign(address, message);
-            return results;
-        }
-
-        public async Task<string> SendTransaction(TransactionData transaction)
-        {
-            var results = await Session.EthSendTransaction(transaction);
-            return results;
-        }
-
-        public async Task<string> SignTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData)
-            where TDomain : IDomain
-        {
-            var address = Session.Accounts[0];
-            return await Session.EthSignTypedData(address, data, typedData);
         }
     }
 }

--- a/Assets/Thirdweb/Plugins/WalletConnectSharp.Unity/WalletConnectUnitySession.cs
+++ b/Assets/Thirdweb/Plugins/WalletConnectSharp.Unity/WalletConnectUnitySession.cs
@@ -54,7 +54,7 @@ namespace WalletConnectSharp.Unity
 
         public override async Task<WCSessionData> ConnectSession()
         {
-            return await unityObjectSource.Connect(ThirdwebManager.Instance.SDK.nativeSession.lastChainId);
+            return await unityObjectSource.Connect(ThirdwebManager.Instance.SDK.session.ChainId);
         }
     }
 }

--- a/Assets/Thirdweb/Plugins/magic-unity/link.magic.unity.sdk/Prefabs/Scripts/MagicUnity.cs
+++ b/Assets/Thirdweb/Plugins/magic-unity/link.magic.unity.sdk/Prefabs/Scripts/MagicUnity.cs
@@ -51,18 +51,4 @@ public class MagicUnity : MonoBehaviour
     {
         await _magic.User.Logout();
     }
-
-    public async Task<string> PersonalSign(string message)
-    {
-        var personalSign = new Nethereum.RPC.Eth.EthSign(_magic.Provider);
-        return await personalSign.SendRequestAsync(await GetAddress(), message);
-    }
-
-    public async Task<string> SignTypedDataV4<T, TDomain>(T data, TypedData<TDomain> typedData)
-        where TDomain : IDomain
-    {
-        Debug.LogWarning("SignTypedDataV4 may not be implemented as part of Magic's Unity SDK.");
-        var signTypedData = new Nethereum.RPC.AccountSigning.EthSignTypedDataV4(_magic.Provider);
-        return await signTypedData.SendRequestAsync(typedData.ToJson(data));
-    }
 }


### PR DESCRIPTION
- Handle local wallet and provider signTypedDataV4 properly
- Fix ERC20 signTypedDataV4
- Move session to ThirdwebSession
- Add interceptor for future use cases, currently eth_accounts
- Remove direct rpc methods from providers' top level scripts
- Update WalletConnect session creation
- Remove async spawns when editor testing
- Add Thirdweb types instead of EthChainData etc.