### PR TITLE
Fix Magic Link Auth Null Reference

### DIFF
--- a/Assets/Thirdweb/Plugins/magic-unity/link.magic.unity.sdk/Prefabs/Scripts/MagicUnity.cs
+++ b/Assets/Thirdweb/Plugins/magic-unity/link.magic.unity.sdk/Prefabs/Scripts/MagicUnity.cs
@@ -49,6 +49,11 @@ public class MagicUnity : MonoBehaviour
 
     public async Task DisableMagicAuth()
     {
+        if (_magic == null)
+        {
+            Debug.LogWarning("Failed to Disable MagicLink Auth because it was not properly initialized.");
+            return;
+        }
         await _magic.User.Logout();
     }
 }


### PR DESCRIPTION
When Magic Link API key is not set, attempting to use it will result in a null reference exception, potentially causing runtime crashes. The proper warnings are already thrown to the debugger so the user knows what to do if this case occurs. This change makes the code safer and throws a warning instead of an error.