### PR TITLE
Wallet Connect Prefab Address Accessor

### DIFF
--- a/Assets/Thirdweb/Examples/Scripts/Prefabs/Prefab_ConnectWallet.cs
+++ b/Assets/Thirdweb/Examples/Scripts/Prefabs/Prefab_ConnectWallet.cs
@@ -73,6 +73,14 @@ public class Prefab_ConnectWallet : MonoBehaviour
     bool connecting;
     WCSessionData wcSessionData;
 
+    public string Address
+    {
+        get
+        {
+            return address;
+        }
+    }
+
     // UI Initialization
 
     private void Start()


### PR DESCRIPTION
Create public accessor to wallet address on connect wallet prefab script.

This small enhancement allows the end-user of the SDK to access the wallet address that has been populated through the wallet connect prefab.