### PR TITLE
Fix null reference exception in Util script.

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Utils.cs
+++ b/Assets/Thirdweb/Core/Scripts/Utils.cs
@@ -110,7 +110,7 @@ namespace Thirdweb
 
         public static string ReplaceIPFS(this string uri, string gateway = "https://gateway.ipfscdn.io/ipfs/")
         {
-            if (uri.StartsWith("ipfs://"))
+            if (!string.IsNullOrEmpty(uri) && uri.StartsWith("ipfs://"))
                 return uri.Replace("ipfs://", gateway);
             else
                 return uri;


### PR DESCRIPTION
* Do not access string method if string value is null.

The case is a null string is passed to this utility method, and the utility method calls a method on this null object, resulting in a runtime null reference exception.