### PR TITLE
Fix ERC1155 GetOwned

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/ERC1155.cs
+++ b/Assets/Thirdweb/Core/Scripts/ERC1155.cs
@@ -116,7 +116,7 @@ namespace Thirdweb
                 List<NFT> ownedNfts = new List<NFT>();
                 for (int i = 0; i < totalCount; i++)
                 {
-                    BigInteger ownedBalance = BigInteger.Parse(await Balance(i.ToString()));
+                    BigInteger ownedBalance = BigInteger.Parse(await Balanceof(owner, i.ToString()));
                     if (ownedBalance == 0)
                     {
                         continue;


### PR DESCRIPTION
When requesting the owned ERC1155 NFTs of a specific address, the SDK would null reference when attempting to access the logged in wallet if the wallet is not currently logged in, despite the address being targeted in the method parameter.

This fixes the null reference, and a bug that would have occurred if the null reference didn't occur: If requesting GetOwned of an address that is **not** the currently logged in wallet, it would have determined that the current wallet owns it or not instead of the method parameter targeted address.