### PR TITLE
Fix WalletConnect GameObject runtime error.

### DIFF
--- a/Assets/Thirdweb/Plugins/WalletConnectSharp.Unity/UI/WalletConnectQRImage.cs
+++ b/Assets/Thirdweb/Plugins/WalletConnectSharp.Unity/UI/WalletConnectQRImage.cs
@@ -61,7 +61,7 @@ public class WalletConnectQRImage : BindableMonoBehavior
         {
             GenerateQrCode();
         }
-        else
+        else if (gameObject.activeInHierarchy)
         {
             StartCoroutine(ShowLoader());
         }


### PR DESCRIPTION
Fix game object attempting to start coroutine when game object is not active in hierarchy.

After connecting to a wallet with WalletConnect, if the application loses focus, and then resumes focus, WalletConnect attempts to start a coroutine to generate a QR code, however the UI is not active and the start coroutine call fails in a runtime error. This change checks if the game object is active before starting the coroutine.

I've tested that WalletConnect is able to properly connect to a wallet after logging out of a wallet and using again.