### PR TITLE
fix: Blurry QR image have made sharpen

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/WalletsUI/MetamaskUI.cs
+++ b/Assets/Thirdweb/Core/Scripts/WalletsUI/MetamaskUI.cs
@@ -81,6 +81,7 @@ namespace Thirdweb.Wallets
             QRCodeImage.sprite = Sprite.Create(qrCodeAsTexture2D, new Rect(0, 0, qrCodeAsTexture2D.width, qrCodeAsTexture2D.height), new Vector2(0.5f, 0.5f));
             DeepLinkButton.onClick.RemoveAllListeners();
             DeepLinkButton.onClick.AddListener(() => Application.OpenURL(url));
+            QRCodeImage.mainTexture.filterMode = FilterMode.Point;
         }
 
         private void OnWalletConnected(object sender, EventArgs e)


### PR DESCRIPTION
Metamask Wallet UI QR image is blurry and some mobile devices can't scan easily. Blurry QR image have made sharpen.