### PR TITLE
Fix Thirdweb Wallet Disconnect Null Reference

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs
+++ b/Assets/Thirdweb/Core/Scripts/ThirdwebSession.cs
@@ -112,7 +112,14 @@ namespace Thirdweb
 
         internal async Task Disconnect()
         {
-            await ActiveWallet.Disconnect();
+            if (ActiveWallet != null)
+            {
+                await ActiveWallet.Disconnect();
+            }
+            else
+            {
+                Debug.LogWarning("No active wallet detected, unable to disconnect.");
+            }
             ThirdwebManager.Instance.SDK.session = new ThirdwebSession(Options, ChainId, RPC);
         }
 


### PR DESCRIPTION
This issue occurred in our project, where the case is that the client has already logged in from a previous session, and we've saved the wallet address. The user then disconnects the wallet, and we clear the wallet address from local storage, and tell Thirdweb to disconnect the current wallet. This results in a null reference exception, as no Thirdweb connection was needed. The solution is to not access the wallet if it is null, and throw a warning instead.

* Do not access active wallet if it is null.
* Add warning.