### PR TITLE
Offline userop/tx signing w/ tx builder for engine + WebGL SignTypedData

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Contract.cs
+++ b/Assets/Thirdweb/Core/Scripts/Contract.cs
@@ -112,7 +112,12 @@ namespace Thirdweb
         public async Task<Transaction> Prepare(string functionName, string from = null, params object[] args)
         {
             var initialInput = new TransactionInput();
-            if (!Utils.IsWebGLBuild())
+            if (Utils.IsWebGLBuild())
+            {
+                initialInput.From = from ?? await ThirdwebManager.Instance.SDK.wallet.GetAddress();
+                initialInput.To = address;
+            }
+            else
             {
                 var contract = Utils.GetWeb3().Eth.GetContract(this.abi, this.address);
                 var function = contract.GetFunction(functionName);

--- a/Assets/Thirdweb/Core/Scripts/Transaction.cs
+++ b/Assets/Thirdweb/Core/Scripts/Transaction.cs
@@ -299,6 +299,28 @@ namespace Thirdweb
         }
 
         /// <summary>
+        /// Signs the transaction asynchronously, if the wallet supports it. Useful for smart wallet user op delayed broadcasting through thirdweb Engine. Otherwise not recommended.
+        /// </summary>
+        /// <returns>The signed transaction a string.</returns>
+        public async Task<string> Sign()
+        {
+            if (Input.Value == null)
+                Input.Value = new HexBigInteger(0);
+
+            if (Utils.IsWebGLBuild())
+            {
+                return await Bridge.InvokeRoute<string>(GetTxBuilderRoute("sign"), Utils.ToJsonStringArray(Input, fnName, fnArgs));
+            }
+            else
+            {
+                if (ThirdwebManager.Instance.SDK.session.ActiveWallet.GetProvider() != WalletProvider.SmartWallet && ThirdwebManager.Instance.SDK.session.ActiveWallet.GetLocalAccount() != null)
+                    return await ThirdwebManager.Instance.SDK.session.ActiveWallet.GetLocalAccount().TransactionManager.SignTransactionAsync(Input);
+                else
+                    return await ThirdwebManager.Instance.SDK.session.Request<string>("eth_signTransaction", Input);
+            }
+        }
+
+        /// <summary>
         /// Sends the transaction asynchronously.
         /// </summary>
         /// <param name="gasless">Specifies whether to send the transaction as a gasless transaction. Default is null (uses gasless if set up).</param>

--- a/Assets/Thirdweb/Core/Scripts/Utils.cs
+++ b/Assets/Thirdweb/Core/Scripts/Utils.cs
@@ -14,6 +14,7 @@ using Newtonsoft.Json.Linq;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Collections;
 
 namespace Thirdweb
 {
@@ -32,8 +33,26 @@ namespace Thirdweb
                 {
                     continue;
                 }
+                // if array or list, check if bytes and convert to hex
+                if (args[i].GetType().IsArray || args[i] is IList)
+                {
+                    var enumerable = args[i] as IEnumerable;
+                    var enumerableArgs = new List<object>();
+                    foreach (var item in enumerable)
+                    {
+                        if (item is byte[])
+                        {
+                            enumerableArgs.Add(ByteArrayToHexString(item as byte[]));
+                        }
+                        else
+                        {
+                            enumerableArgs.Add(item);
+                        }
+                    }
+                    stringArgs.Add(ToJson(enumerableArgs));
+                }
                 // if bytes, make hex
-                if (args[i] is byte[])
+                else if (args[i] is byte[])
                 {
                     stringArgs.Add(ByteArrayToHexString(args[i] as byte[]));
                 }
@@ -44,7 +63,7 @@ namespace Thirdweb
                 }
                 else
                 {
-                    stringArgs.Add(Utils.ToJson(args[i]));
+                    stringArgs.Add(ToJson(args[i]));
                 }
             }
             return stringArgs.ToArray();

--- a/Assets/Thirdweb/Core/Scripts/Wallet.cs
+++ b/Assets/Thirdweb/Core/Scripts/Wallet.cs
@@ -510,16 +510,6 @@ namespace Thirdweb
             if (!await IsConnected())
                 throw new Exception("No account connected!");
 
-            if (ThirdwebManager.Instance.SDK.session.ActiveWallet.GetProvider() == WalletProvider.SmartWallet)
-            {
-                var sw = ThirdwebManager.Instance.SDK.session.ActiveWallet as Wallets.ThirdwebSmartWallet;
-                if (!sw.SmartWallet.IsDeployed && !sw.SmartWallet.IsDeploying)
-                {
-                    ThirdwebDebug.Log("SmartWallet not deployed, deploying before signing...");
-                    await sw.SmartWallet.ForceDeploy();
-                }
-            }
-
             if (ThirdwebManager.Instance.SDK.session.ActiveWallet.GetLocalAccount() != null)
             {
                 var signer = new Eip712TypedDataSigner();

--- a/Assets/Thirdweb/Examples/Scripts/Prefabs/Prefab_SmartWallet.cs
+++ b/Assets/Thirdweb/Examples/Scripts/Prefabs/Prefab_SmartWallet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -54,6 +55,45 @@ namespace Thirdweb.Examples
             catch (System.Exception e)
             {
                 Debugger.Instance.Log("[CreateSessionKey] Error", e.Message);
+            }
+        }
+
+        public async void PreSignSessionKeyTxAsUserOpForLaterBroadcastingThroughThirdwebEngine()
+        {
+            try
+            {
+                var accountAddress = await ThirdwebManager.Instance.SDK.wallet.GetAddress();
+                var accountContract = ThirdwebManager.Instance.SDK.GetContract(
+                    accountAddress,
+                    "[{\"type\": \"function\",\"name\": \"setPermissionsForSigner\",\"inputs\": [{\"type\": \"tuple\",\"name\": \"_req\",\"components\": [{\"type\": \"address\",\"name\": \"signer\",\"internalType\": \"address\"},{\"type\": \"uint8\",\"name\": \"isAdmin\",\"internalType\": \"uint8\"},{\"type\": \"address[]\",\"name\": \"approvedTargets\",\"internalType\": \"address[]\"},{\"type\": \"uint256\",\"name\": \"nativeTokenLimitPerTransaction\",\"internalType\": \"uint256\"},{\"type\": \"uint128\",\"name\": \"permissionStartTimestamp\",\"internalType\": \"uint128\"},{\"type\": \"uint128\",\"name\": \"permissionEndTimestamp\",\"internalType\": \"uint128\"},{\"type\": \"uint128\",\"name\": \"reqValidityStartTimestamp\",\"internalType\": \"uint128\"},{\"type\": \"uint128\",\"name\": \"reqValidityEndTimestamp\",\"internalType\": \"uint128\"},{\"type\": \"bytes32\",\"name\": \"uid\",\"internalType\": \"bytes32\"}],\"internalType\": \"struct IAccountPermissions.SignerPermissionRequest\"},{\"type\": \"bytes\",\"name\": \"_signature\",\"internalType\": \"bytes\"}],\"outputs\": [],\"stateMutability\": \"nonpayable\"}]"
+                );
+                var contractsAllowedForInteraction = new List<string>() { "0x450b943729Ddba196Ab58b589Cea545551DF71CC" };
+                var request = new Contracts.Account.ContractDefinition.SignerPermissionRequest()
+                {
+                    Signer = "0x22b79AD6c6009525933ac2FF40bC9F30dF14Ecfb",
+                    IsAdmin = 0,
+                    ApprovedTargets = contractsAllowedForInteraction,
+                    NativeTokenLimitPerTransaction = 0,
+                    PermissionStartTimestamp = 0,
+                    PermissionEndTimestamp = Utils.GetUnixTimeStampNow() + 86400,
+                    ReqValidityStartTimestamp = 0,
+                    ReqValidityEndTimestamp = Utils.GetUnixTimeStampIn10Years(),
+                    Uid = Guid.NewGuid().ToByteArray()
+                };
+                var signature = await EIP712.GenerateSignature_SmartAccount(
+                    "Account",
+                    "1",
+                    await ThirdwebManager.Instance.SDK.wallet.GetChainId(),
+                    await ThirdwebManager.Instance.SDK.wallet.GetAddress(),
+                    request
+                );
+                var tx = await accountContract.Prepare("setPermissionsForSigner", request, signature.HexStringToByteArray());
+                var signedTx = await tx.Sign();
+                Debugger.Instance.Log("[Pre-Sign Session Key User Op] Sucess", signedTx.ToString());
+            }
+            catch (System.Exception e)
+            {
+                Debugger.Instance.Log("[Pre-Sign Session Key User Op] Error", e.Message);
             }
         }
     }


### PR DESCRIPTION
Unlocks `Transaction.Sign`, enables presigning of txs if wallet supports it, and more importantly supports presigned userops and avoids deployment when the purpose is presigning 712 sessionkey transactions using undeployed accounts, includes initcode in result. Allows broadcasting later on through engine `/transaction/{chainId}/send-signed-user-op`

Example included in the longest method name ever `PreSignSessionKeyTxAsUserOpForLaterBroadcastingThroughThirdwebEngine` in `Prefab_SmartWallet`.