### PR TITLE
Override and improve gas fees when not provided

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Contract.cs
+++ b/Assets/Thirdweb/Core/Scripts/Contract.cs
@@ -213,13 +213,30 @@ namespace Thirdweb
 
                 var gasPrice = transactionOverrides?.gasPrice != null ? new HexBigInteger(BigInteger.Parse(transactionOverrides?.gasPrice)) : null;
 
-                var hash = await function.SendTransactionAsync(
-                    from: transactionOverrides?.from ?? await ThirdwebManager.Instance.SDK.wallet.GetAddress(),
-                    gas: gas,
-                    gasPrice: gasPrice,
-                    value: value,
-                    args
-                );
+                string hash;
+                if (gasPrice == null)
+                {
+                    var gasFees = await Utils.GetGasPriceAsync(await ThirdwebManager.Instance.SDK.wallet.GetChainId());
+                    hash = await function.SendTransactionAsync(
+                        from: transactionOverrides?.from ?? await ThirdwebManager.Instance.SDK.wallet.GetAddress(),
+                        gas: gas,
+                        value: value,
+                        maxFeePerGas: new HexBigInteger(gasFees.MaxFeePerGas),
+                        maxPriorityFeePerGas: new HexBigInteger(gasFees.MaxPriorityFeePerGas),
+                        args
+                    );
+                }
+                else
+                {
+                    hash = await function.SendTransactionAsync(
+                        from: transactionOverrides?.from ?? await ThirdwebManager.Instance.SDK.wallet.GetAddress(),
+                        gas: gas,
+                        gasPrice: gasPrice,
+                        value: value,
+                        args
+                    );
+                }
+
                 return await Transaction.WaitForTransactionResult(hash);
             }
         }

--- a/Assets/Thirdweb/Core/Scripts/TransactionManager.cs
+++ b/Assets/Thirdweb/Core/Scripts/TransactionManager.cs
@@ -94,6 +94,14 @@ namespace Thirdweb
 
             if (!isGasless)
             {
+                if (functionMessage.GasPrice == null && functionMessage.MaxFeePerGas == null && functionMessage.MaxPriorityFeePerGas == null)
+                {
+                    var gasPrice = await Utils.GetGasPriceAsync(await ThirdwebManager.Instance.SDK.wallet.GetChainId());
+                    functionMessage.GasPrice = gasPrice.MaxFeePerGas;
+                    functionMessage.MaxFeePerGas = gasPrice.MaxFeePerGas;
+                    functionMessage.MaxPriorityFeePerGas = gasPrice.MaxPriorityFeePerGas;
+                }
+
                 if (
                     ThirdwebManager.Instance.SDK.session.ActiveWallet.GetSignerProvider() == WalletProvider.LocalWallet
                     && ThirdwebManager.Instance.SDK.session.ActiveWallet.GetProvider() != WalletProvider.SmartWallet


### PR DESCRIPTION
Also fixes Fantom type chains fee history issues

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance gas price handling in transactions by setting default values if not provided.

### Detailed summary
- Set default gas price values if not provided in `TransactionManager.cs`
- Retrieve gas fees if gas price is null in `Contract.cs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->