### PR TITLE
thirdweb_getUserOperationGasPrice

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/AccountAbstraction/Core/BundlerClient.cs
+++ b/Assets/Thirdweb/Core/Scripts/AccountAbstraction/Core/BundlerClient.cs
@@ -34,6 +34,12 @@ namespace Thirdweb.AccountAbstraction
             return JsonConvert.DeserializeObject<EthEstimateUserOperationGasResponse>(response.Result.ToString());
         }
 
+        public static async Task<ThirdwebGetUserOperationGasPriceResponse> ThirdwebGetUserOperationGasPrice(string bundlerUrl, string apiKey, object requestId)
+        {
+            var response = await BundlerRequest(bundlerUrl, apiKey, requestId, "thirdweb_getUserOperationGasPrice");
+            return JsonConvert.DeserializeObject<ThirdwebGetUserOperationGasPriceResponse>(response.Result.ToString());
+        }
+
         // Paymaster requests
 
         public static async Task<PMSponsorOperationResponse> PMSponsorUserOperation(string paymasterUrl, string apiKey, object requestId, UserOperationHexified userOp, string entryPoint)

--- a/Assets/Thirdweb/Core/Scripts/AccountAbstraction/Core/SmartWallet.cs
+++ b/Assets/Thirdweb/Core/Scripts/AccountAbstraction/Core/SmartWallet.cs
@@ -211,7 +211,20 @@ namespace Thirdweb.AccountAbstraction
 
             var (initCode, gas) = await GetInitCode();
 
-            var gasPrices = await Utils.GetGasPriceAsync(ThirdwebManager.Instance.SDK.Session.ChainId);
+            BigInteger maxFee;
+            BigInteger maxPriorityFee;
+            if (new Uri(Config.bundlerUrl).Host.EndsWith(".thirdweb.com"))
+            {
+                var fees = await BundlerClient.ThirdwebGetUserOperationGasPrice(Config.bundlerUrl, apiKey, requestId);
+                maxFee = new HexBigInteger(fees.maxFeePerGas).Value;
+                maxPriorityFee = new HexBigInteger(fees.maxPriorityFeePerGas).Value;
+            }
+            else
+            {
+                var fees = await Utils.GetGasPriceAsync(ThirdwebManager.Instance.SDK.Session.ChainId);
+                maxFee = fees.MaxFeePerGas;
+                maxPriorityFee = fees.MaxPriorityFeePerGas;
+            }
 
             var partialUserOp = new EntryPointContract.UserOperation()
             {
@@ -222,8 +235,8 @@ namespace Thirdweb.AccountAbstraction
                 CallGasLimit = 0,
                 VerificationGasLimit = 0,
                 PreVerificationGas = 0,
-                MaxFeePerGas = gasPrices.MaxFeePerGas,
-                MaxPriorityFeePerGas = gasPrices.MaxPriorityFeePerGas,
+                MaxFeePerGas = maxFee,
+                MaxPriorityFeePerGas = maxPriorityFee,
                 PaymasterAndData = new byte[] { },
                 Signature = Constants.DUMMY_SIG.HexStringToByteArray(),
             };

--- a/Assets/Thirdweb/Core/Scripts/AccountAbstraction/Core/Types.cs
+++ b/Assets/Thirdweb/Core/Scripts/AccountAbstraction/Core/Types.cs
@@ -31,4 +31,10 @@ namespace Thirdweb.AccountAbstraction
     {
         public string paymasterAndData { get; set; }
     }
+
+    public class ThirdwebGetUserOperationGasPriceResponse
+    {
+        public string maxFeePerGas { get; set; }
+        public string maxPriorityFeePerGas { get; set; }
+    }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new class `ThirdwebGetUserOperationGasPriceResponse` and updates `SmartWallet.cs` to fetch gas prices from a bundler service when applicable.

### Detailed summary
- Added `ThirdwebGetUserOperationGasPriceResponse` class
- Updated `SmartWallet.cs` to fetch gas prices from bundler service or default gas prices

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->