### PR TITLE
Fix main thread encryption/decryption freeze

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Wallet.cs
+++ b/Assets/Thirdweb/Core/Scripts/Wallet.cs
@@ -91,7 +91,7 @@ namespace Thirdweb
             else
             {
                 var localAccount = ThirdwebManager.Instance.SDK.Session.ActiveWallet.GetLocalAccount() ?? throw new Exception("No local account found");
-                return Utils.EncryptAndGenerateKeyStore(new EthECKey(localAccount.PrivateKey), password);
+                return await Utils.EncryptAndGenerateKeyStore(new EthECKey(localAccount.PrivateKey), password);
             }
         }
 

--- a/Assets/Thirdweb/Core/Scripts/Wallets/ThirdwebLocalWallet.cs
+++ b/Assets/Thirdweb/Core/Scripts/Wallets/ThirdwebLocalWallet.cs
@@ -20,11 +20,11 @@ namespace Thirdweb.Wallets
             _signerProvider = WalletProvider.LocalWallet;
         }
 
-        public Task<string> Connect(WalletConnection walletConnection, string rpc)
+        public async Task<string> Connect(WalletConnection walletConnection, string rpc)
         {
-            _account = Utils.UnlockOrGenerateLocalAccount(walletConnection.chainId, walletConnection.password, null);
+            _account = await Utils.UnlockOrGenerateLocalAccount(walletConnection.chainId, walletConnection.password, null);
             _web3 = new Web3(_account, rpc);
-            return Task.FromResult(_account.Address);
+            return _account.Address;
         }
 
         public Task Disconnect(bool endSession = true)


### PR DESCRIPTION
A little slower for LocalWallet but better UX
Not doing this for EWS due to much heavier crypto operations that might take 10+ seconds to initial encryption, specially bad on mobile, best to do on main thread freeze 1-2s

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement asynchronous operations in key generation and account unlocking processes.

### Detailed summary
- Updated methods in `Wallet.cs`, `ThirdwebLocalWallet.cs`, and `Utils.cs` to use `async` and `await` for asynchronous operations.
- Replaced synchronous file operations with asynchronous operations for improved performance.
- Modified return types to `Task` or `Task<string>` for asynchronous handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->