### PR TITLE
Fix: Missing developer client id or redirect url or platform in query param

### DIFF
--- a/Assets/Thirdweb/Core/Scripts/Wallets/ThirdwebInAppWallet.cs
+++ b/Assets/Thirdweb/Core/Scripts/Wallets/ThirdwebInAppWallet.cs
@@ -20,6 +20,7 @@ namespace Thirdweb.Wallets
         public ThirdwebInAppWallet(string clientId, string bundleId)
         {
             _web3 = null;
+            _clientId = clientId;
             _provider = WalletProvider.InAppWallet;
             _signerProvider = WalletProvider.LocalWallet;
             _embeddedWallet = new EmbeddedWallet(clientId, bundleId, "unity", ThirdwebSDK.version);

--- a/Assets/Thirdweb/Core/Scripts/WalletsUI/InAppWalletUI.cs
+++ b/Assets/Thirdweb/Core/Scripts/WalletsUI/InAppWalletUI.cs
@@ -39,7 +39,7 @@ namespace Thirdweb.Wallets
         protected string _callbackUrl;
         protected string _customScheme;
         protected CancellationTokenSource _cancellationTokenSource;
-        protected string clientId;
+        protected string _clientId;
 
         #endregion
 
@@ -74,6 +74,7 @@ namespace Thirdweb.Wallets
             _embeddedWallet = embeddedWallet;
             _email = email;
             _phone = phoneNumber;
+            _clientId = clientId;
             _user = null;
             _exception = null;
             OTPInput.text = "";
@@ -367,7 +368,7 @@ namespace Thirdweb.Wallets
             string loginUrl = await _embeddedWallet.FetchHeadlessOauthLoginLinkAsync(authProvider);
             string platform = "unity";
             string redirectUrl = UnityWebRequest.EscapeURL(Application.isMobilePlatform ? _customScheme : "http://localhost:8789/");
-            string developerClientId = UnityWebRequest.EscapeURL(clientId);
+            string developerClientId = UnityWebRequest.EscapeURL(_clientId);
             return $"{loginUrl}?platform={platform}&redirectUrl={redirectUrl}&developerClientId={developerClientId}&authOption={authProvider}";
         }
 


### PR DESCRIPTION
Fixed oauth issue.
Step to reproduce:
1. Login using google in unity
2. Stop game
3. Change your client id in ThirwebManager prefab
4. Try to login again
5. Receive Missing developer client id or redirect url or platform in query param

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ThirdwebInAppWallet` and `InAppWalletUI` classes by adding and using the `_clientId` field instead of `clientId`.

### Detailed summary
- Added `_clientId` field in `ThirdwebInAppWallet` constructor
- Changed `clientId` to `_clientId` in `InAppWalletUI`
- Updated references to `clientId` with `_clientId` in `InAppWalletUI`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->