### PR TITLE
configuartion of syncCtx check

### DIFF
--- a/Assets/Thirdweb/Plugins/WalletConnectUnity/com.walletconnect.core/Runtime/WalletConnect.cs
+++ b/Assets/Thirdweb/Plugins/WalletConnectUnity/com.walletconnect.core/Runtime/WalletConnect.cs
@@ -69,7 +69,8 @@ namespace WalletConnectUnity.Core
                 }
 
                 var currentSyncContext = SynchronizationContext.Current;
-                if (currentSyncContext.GetType().FullName != "UnityEngine.UnitySynchronizationContext")
+                bool isSkipSyncCtxCheck = AppContext.TryGetSwitch("IsSkipWalletConnectSyncCtxCheck", out var isEnabled) && isEnabled;
+                if (!isSkipSyncCtxCheck && currentSyncContext.GetType().FullName != "UnityEngine.UnitySynchronizationContext")
                     throw new Exception(
                         $"[WalletConnectUnity] SynchronizationContext is not of type UnityEngine.UnitySynchronizationContext. Current type is <i>{currentSyncContext.GetType().FullName}</i>. Make sure to initialize WalletConnect from the main thread."
                     );


### PR DESCRIPTION
fix https://github.com/thirdweb-dev/unity-sdk/issues/215

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a conditional check for the synchronization context in the `WalletConnect.cs` file, allowing for flexibility in the synchronization context validation based on a configuration switch.

### Detailed summary
- Added a boolean `isSkipSyncCtxCheck` to determine if the synchronization context check should be skipped.
- Updated the `if` statement to include the `isSkipSyncCtxCheck` condition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->