### PR TITLE
Backend Auth + ThirdwebManagerServer

### DIFF
--- a/Assets/Thirdweb/Editor/ThirdwebManagerEditor.cs
+++ b/Assets/Thirdweb/Editor/ThirdwebManagerEditor.cs
@@ -5,125 +5,61 @@ using System.Reflection;
 
 namespace Thirdweb.Editor
 {
-    [CustomEditor(typeof(ThirdwebManager))]
-    public class ThirdwebManagerEditor : UnityEditor.Editor
+    public abstract class ThirdwebManagerBaseEditor<T> : UnityEditor.Editor
+        where T : MonoBehaviour
     {
-        private SerializedProperty clientIdProp;
-        private SerializedProperty bundleIdProp;
-        private SerializedProperty initializeOnAwakeProp;
-        private SerializedProperty showDebugLogsProp;
-        private SerializedProperty optOutUsageAnalyticsProp;
-        private SerializedProperty autoConnectLastWallet;
-        private SerializedProperty supportedChainsProp;
-        private SerializedProperty includedWalletIdsProp;
-        private SerializedProperty redirectPageHtmlOverrideProp;
-        private SerializedProperty rpcOverridesProp;
+        protected SerializedProperty initializeOnAwakeProp;
+        protected SerializedProperty showDebugLogsProp;
+        protected SerializedProperty optOutUsageAnalyticsProp;
+        protected SerializedProperty autoConnectLastWalletProp;
+        protected SerializedProperty supportedChainsProp;
+        protected SerializedProperty includedWalletIdsProp;
+        protected SerializedProperty redirectPageHtmlOverrideProp;
+        protected SerializedProperty rpcOverridesProp;
 
-        private int selectedTab = 0;
-        private readonly string[] tabTitles = { "Client", "Preferences", "Misc", "Debug" };
+        protected int selectedTab;
+        protected GUIStyle buttonStyle;
+        protected Texture2D bannerImage;
 
-        private GUIStyle headerStyle;
-        private GUIStyle buttonStyle;
+        protected virtual string[] TabTitles => new string[] { "Client/Server", "Preferences", "Misc", "Debug" };
 
-        private Texture2D bannerImage;
-
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
-            clientIdProp = FindProperty("ClientId");
-            bundleIdProp = FindProperty("BundleId");
-            initializeOnAwakeProp = FindProperty("InitializeOnAwake");
-            showDebugLogsProp = FindProperty("ShowDebugLogs");
-            optOutUsageAnalyticsProp = FindProperty("OptOutUsageAnalytics");
-            autoConnectLastWallet = FindProperty("AutoConnectLastWallet");
-            supportedChainsProp = FindProperty("SupportedChains");
-            includedWalletIdsProp = FindProperty("IncludedWalletIds");
-            redirectPageHtmlOverrideProp = FindProperty("RedirectPageHtmlOverride");
-            rpcOverridesProp = FindProperty("RpcOverrides");
+            initializeOnAwakeProp = FindProp("InitializeOnAwake");
+            showDebugLogsProp = FindProp("ShowDebugLogs");
+            optOutUsageAnalyticsProp = FindProp("OptOutUsageAnalytics");
+            autoConnectLastWalletProp = FindProp("AutoConnectLastWallet");
+            supportedChainsProp = FindProp("SupportedChains");
+            includedWalletIdsProp = FindProp("IncludedWalletIds");
+            redirectPageHtmlOverrideProp = FindProp("RedirectPageHtmlOverride");
+            rpcOverridesProp = FindProp("RpcOverrides");
 
             bannerImage = Resources.Load<Texture2D>("EditorBanner");
-        }
-
-        private void InitializeStyles()
-        {
-            buttonStyle = new GUIStyle(GUI.skin.button)
-            {
-                fontStyle = FontStyle.Bold,
-                alignment = TextAnchor.MiddleLeft,
-                padding = new RectOffset(10, 10, 10, 10)
-            };
-        }
-
-        private SerializedProperty FindProperty(string propertyName)
-        {
-            var targetType = target.GetType();
-            var property = targetType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-            if (property == null)
-                return null;
-
-            var backingFieldName = $"<{propertyName}>k__BackingField";
-            return serializedObject.FindProperty(backingFieldName);
         }
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
-            if (headerStyle == null || buttonStyle == null)
+            if (buttonStyle == null)
             {
                 InitializeStyles();
             }
 
-            // Draw Banner and Title
             DrawBannerAndTitle();
-
-            // Draw Tab Bar
             DrawTabs();
-
-            // Draw Selected Tab Content
             GUILayout.Space(10);
             DrawSelectedTabContent();
 
             serializedObject.ApplyModifiedProperties();
         }
 
-        private void DrawBannerAndTitle()
-        {
-            GUILayout.BeginVertical();
-            GUILayout.Space(10);
-
-            GUILayout.BeginHorizontal();
-
-            if (bannerImage != null)
-            {
-                GUILayout.Label(bannerImage, GUILayout.Width(64), GUILayout.Height(64));
-            }
-
-            GUILayout.Space(10);
-
-            GUILayout.BeginVertical();
-            GUILayout.Space(10);
-            GUILayout.Label("Thirdweb Configuration", EditorStyles.boldLabel);
-            GUILayout.Label("Configure your settings and preferences.\nYou can access ThirdwebManager.Instance from anywhere.", EditorStyles.miniLabel);
-            GUILayout.EndVertical();
-
-            GUILayout.EndHorizontal();
-
-            GUILayout.Space(10);
-
-            GUILayout.EndVertical();
-        }
-
-        private void DrawTabs()
-        {
-            selectedTab = GUILayout.Toolbar(selectedTab, tabTitles, GUILayout.Height(25));
-        }
-
-        private void DrawSelectedTabContent()
+        protected virtual void DrawSelectedTabContent()
         {
             switch (selectedTab)
             {
                 case 0:
-                    DrawClientTab();
+                    DrawClientOrServerTab();
                     break;
                 case 1:
                     DrawPreferencesTab();
@@ -140,83 +76,55 @@ namespace Thirdweb.Editor
             }
         }
 
-        private void DrawClientTab()
-        {
-            EditorGUILayout.HelpBox("Configure your client settings here.", MessageType.Info);
-            DrawProperty(clientIdProp, "Client ID", "Your Thirdweb Client ID. You can find this in the Thirdweb Dashboard by creating a project.");
-            DrawProperty(bundleIdProp, "Bundle ID", "You may allowlist a bundle ID in the Thirdweb Dashboard to allow native apps to access our services, eg com.mycompany.myapp");
-            DrawButton(
-                "Create API Key",
-                () =>
-                {
-                    Application.OpenURL("https://thirdweb.com/create-api-key");
-                }
-            );
-        }
+        protected abstract void DrawClientOrServerTab();
 
-        private void DrawPreferencesTab()
+        protected virtual void DrawPreferencesTab()
         {
             EditorGUILayout.HelpBox("Set your preferences and initialization options here.", MessageType.Info);
-            DrawProperty(initializeOnAwakeProp, "Initialize On Awake", "If enabled, Thirdweb will initialize on Awake. If disabled, you must call ThirdwebManager.Instance.Initialize() manually.");
-            DrawProperty(showDebugLogsProp, "Show Debug Logs", "If enabled, Thirdweb will log debug messages to the console.");
-            DrawProperty(optOutUsageAnalyticsProp, "Opt-Out of Usage Analytics", "If enabled, you may see inconsistent stats in your Thirdweb Dashboard.");
-            DrawProperty(
-                autoConnectLastWallet,
-                "Auto-Connect Last Wallet",
-                "If enabled, Thirdweb will automatically connect to the last connected wallet on initialization (this behavior does not apply to the WalletConnectWallet provider option)."
-            );
+            DrawProperty(initializeOnAwakeProp, "Initialize On Awake");
+            DrawProperty(showDebugLogsProp, "Show Debug Logs");
+            DrawProperty(optOutUsageAnalyticsProp, "Opt-Out of Usage Analytics");
+            DrawProperty(autoConnectLastWalletProp, "Auto-Connect Last Wallet");
         }
 
-        private void DrawMiscTab()
+        protected virtual void DrawMiscTab()
         {
             EditorGUILayout.HelpBox("Configure other settings here.", MessageType.Info);
-
-            // RPC Overrides
-            DrawProperty(rpcOverridesProp, "RPC Overrides", "We recommend using our default RPC, but if you encounter issues you may override them by chain id here.");
-
+            DrawProperty(rpcOverridesProp, "RPC Overrides");
             GUILayout.Space(10);
-
-            // Desktop OAuth Settings
-            EditorGUILayout.LabelField(
-                new GUIContent("OAuth Redirect Page HTML Override", "The HTML displayed after Social Login on Desktop, you may override it to match your branding."),
-                EditorStyles.boldLabel
-            );
+            EditorGUILayout.LabelField("OAuth Redirect Page HTML Override", EditorStyles.boldLabel);
             redirectPageHtmlOverrideProp.stringValue = EditorGUILayout.TextArea(redirectPageHtmlOverrideProp.stringValue, GUILayout.MinHeight(75));
-
             GUILayout.Space(10);
-
-            // Wallet Connect Settings
-            DrawProperty(
-                supportedChainsProp,
-                "WalletConnect Supported Chains",
-                "You technically connect to multiple chains at once with WC, so try to include all chain ids your app wants to support."
-            );
-
-            DrawProperty(
-                includedWalletIdsProp,
-                "WalletConnect Included Wallet IDs",
-                "If displaying less than 3 wallets look for ConnectView script in your hierarchy and edit WC Modal wallet count and other settings there."
-            );
+            DrawProperty(supportedChainsProp, "WalletConnect Supported Chains");
+            DrawProperty(includedWalletIdsProp, "WalletConnect Included Wallet IDs");
         }
 
-        private void DrawDebugTab()
+        protected virtual void DrawDebugTab()
         {
             EditorGUILayout.HelpBox("Debug your settings here.", MessageType.Info);
-
             DrawButton(
                 "Log Active Wallet Info",
                 () =>
                 {
                     if (Application.isPlaying)
                     {
-                        var wallet = ((ThirdwebManager)target).GetActiveWallet();
-                        if (wallet != null)
+                        var mgr = target as T;
+                        var method = mgr.GetType().GetMethod("GetActiveWallet", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                        if (method != null)
                         {
-                            Debug.Log($"Active Wallet ({wallet.GetType().Name}) Address: {wallet.GetAddress().Result}");
+                            var wallet = method.Invoke(mgr, null) as IThirdwebWallet;
+                            if (wallet != null)
+                            {
+                                Debug.Log($"Active Wallet ({wallet.GetType().Name}) Address: {wallet.GetAddress().Result}");
+                            }
+                            else
+                            {
+                                Debug.LogWarning("No active wallet found.");
+                            }
                         }
                         else
                         {
-                            Debug.LogWarning("No active wallet found.");
+                            Debug.LogWarning("GetActiveWallet() not found.");
                         }
                     }
                     else
@@ -225,7 +133,6 @@ namespace Thirdweb.Editor
                     }
                 }
             );
-
             DrawButton(
                 "Open Documentation",
                 () =>
@@ -235,11 +142,46 @@ namespace Thirdweb.Editor
             );
         }
 
-        private void DrawProperty(SerializedProperty property, string label, string tooltip = null)
+        protected void DrawBannerAndTitle()
+        {
+            GUILayout.BeginVertical();
+            GUILayout.Space(10);
+            GUILayout.BeginHorizontal();
+            if (bannerImage != null)
+            {
+                GUILayout.Label(bannerImage, GUILayout.Width(64), GUILayout.Height(64));
+            }
+            GUILayout.Space(10);
+            GUILayout.BeginVertical();
+            GUILayout.Space(10);
+            GUILayout.Label("Thirdweb Configuration", EditorStyles.boldLabel);
+            GUILayout.Label("Configure your settings and preferences.\nYou can access ThirdwebManager.Instance from anywhere.", EditorStyles.miniLabel);
+            GUILayout.EndVertical();
+            GUILayout.EndHorizontal();
+            GUILayout.Space(10);
+            GUILayout.EndVertical();
+        }
+
+        protected void DrawTabs()
+        {
+            selectedTab = GUILayout.Toolbar(selectedTab, TabTitles, GUILayout.Height(25));
+        }
+
+        protected void InitializeStyles()
+        {
+            buttonStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleLeft,
+                padding = new RectOffset(10, 10, 10, 10)
+            };
+        }
+
+        protected void DrawProperty(SerializedProperty property, string label)
         {
             if (property != null)
             {
-                EditorGUILayout.PropertyField(property, new GUIContent(label, tooltip));
+                EditorGUILayout.PropertyField(property, new GUIContent(label));
             }
             else
             {
@@ -247,15 +189,81 @@ namespace Thirdweb.Editor
             }
         }
 
-        private void DrawButton(string label, System.Action action)
+        protected void DrawButton(string label, System.Action action)
         {
             GUILayout.FlexibleSpace();
-            // center label
             if (GUILayout.Button(label, buttonStyle, GUILayout.Height(35), GUILayout.ExpandWidth(true)))
             {
                 action.Invoke();
             }
             GUILayout.FlexibleSpace();
+        }
+
+        protected SerializedProperty FindProp(string propName)
+        {
+            var targetType = target.GetType();
+            var property = targetType.GetProperty(propName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (property == null)
+                return null;
+            var backingFieldName = $"<{propName}>k__BackingField";
+            return serializedObject.FindProperty(backingFieldName);
+        }
+    }
+
+    [CustomEditor(typeof(ThirdwebManager))]
+    public class ThirdwebManagerEditor : ThirdwebManagerBaseEditor<ThirdwebManager>
+    {
+        SerializedProperty clientIdProp;
+        SerializedProperty bundleIdProp;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            clientIdProp = FindProp("ClientId");
+            bundleIdProp = FindProp("BundleId");
+        }
+
+        protected override string[] TabTitles => new string[] { "Client", "Preferences", "Misc", "Debug" };
+
+        protected override void DrawClientOrServerTab()
+        {
+            EditorGUILayout.HelpBox("Configure your client settings here.", MessageType.Info);
+            DrawProperty(clientIdProp, "Client ID");
+            DrawProperty(bundleIdProp, "Bundle ID");
+            DrawButton(
+                "Create API Key",
+                () =>
+                {
+                    Application.OpenURL("https://thirdweb.com/create-api-key");
+                }
+            );
+        }
+    }
+
+    [CustomEditor(typeof(ThirdwebManagerServer))]
+    public class ThirdwebManagerServerEditor : ThirdwebManagerBaseEditor<ThirdwebManagerServer>
+    {
+        SerializedProperty secretKeyProp;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            secretKeyProp = FindProp("SecretKey");
+        }
+
+        protected override string[] TabTitles => new string[] { "Client", "Preferences", "Misc", "Debug" };
+
+        protected override void DrawClientOrServerTab()
+        {
+            EditorGUILayout.HelpBox("Configure your client settings here.", MessageType.Info);
+            DrawProperty(secretKeyProp, "Secret Key");
+            DrawButton(
+                "Create API Key",
+                () =>
+                {
+                    Application.OpenURL("https://thirdweb.com/create-api-key");
+                }
+            );
         }
     }
 }

--- a/Assets/Thirdweb/Runtime/Unity/Prefabs/ThirdwebManagerServer.prefab
+++ b/Assets/Thirdweb/Runtime/Unity/Prefabs/ThirdwebManagerServer.prefab
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2985666425045432145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7977017408921700919}
+  - component: {fileID: 5964706357837968276}
+  m_Layer: 0
+  m_Name: ThirdwebManagerServer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7977017408921700919
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2985666425045432145}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5964706357837968276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2985666425045432145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a197f9da6b1311840bb25b207982e287, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <InitializeOnAwake>k__BackingField: 1
+  <ShowDebugLogs>k__BackingField: 1
+  <OptOutUsageAnalytics>k__BackingField: 0
+  <AutoConnectLastWallet>k__BackingField: 0
+  <SupportedChains>k__BackingField: ee6e060000000000
+  <IncludedWalletIds>k__BackingField: []
+  <RedirectPageHtmlOverride>k__BackingField: 
+  <RpcOverrides>k__BackingField: []
+  <SecretKey>k__BackingField: 

--- a/Assets/Thirdweb/Runtime/Unity/Prefabs/ThirdwebManagerServer.prefab.meta
+++ b/Assets/Thirdweb/Runtime/Unity/Prefabs/ThirdwebManagerServer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: afb575e501b7e2342b3080838f0545cb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerBase.cs
+++ b/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerBase.cs
@@ -1,0 +1,627 @@
+using UnityEngine;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using System.Linq;
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Thirdweb.Unity
+{
+    [Serializable]
+    public enum WalletProvider
+    {
+        PrivateKeyWallet,
+        InAppWallet,
+        WalletConnectWallet,
+        MetaMaskWallet,
+        EcosystemWallet
+    }
+
+    [Serializable]
+    public class InAppWalletOptions : EcosystemWalletOptions
+    {
+        public InAppWalletOptions(
+            string email = null,
+            string phoneNumber = null,
+            AuthProvider authprovider = AuthProvider.Default,
+            string jwtOrPayload = null,
+            string storageDirectoryPath = null,
+            IThirdwebWallet siweSigner = null,
+            string legacyEncryptionKey = null,
+            string walletSecret = null
+        )
+            : base(
+                email: email,
+                phoneNumber: phoneNumber,
+                authprovider: authprovider,
+                jwtOrPayload: jwtOrPayload,
+                storageDirectoryPath: storageDirectoryPath,
+                siweSigner: siweSigner,
+                legacyEncryptionKey: legacyEncryptionKey,
+                walletSecret: walletSecret
+            ) { }
+    }
+
+    [Serializable]
+    public class EcosystemWalletOptions
+    {
+        [JsonProperty("ecosystemId")]
+        public string EcosystemId;
+
+        [JsonProperty("ecosystemPartnerId")]
+        public string EcosystemPartnerId;
+
+        [JsonProperty("email")]
+        public string Email;
+
+        [JsonProperty("phoneNumber")]
+        public string PhoneNumber;
+
+        [JsonProperty("authProvider")]
+        public AuthProvider AuthProvider;
+
+        [JsonProperty("jwtOrPayload")]
+        public string JwtOrPayload;
+
+        [JsonProperty("storageDirectoryPath")]
+        public string StorageDirectoryPath;
+
+        [JsonProperty("siweSigner")]
+        public IThirdwebWallet SiweSigner;
+
+        [JsonProperty("legacyEncryptionKey")]
+        public string LegacyEncryptionKey;
+
+        [JsonProperty("walletSecret")]
+        public string WalletSecret;
+
+        public EcosystemWalletOptions(
+            string ecosystemId = null,
+            string ecosystemPartnerId = null,
+            string email = null,
+            string phoneNumber = null,
+            AuthProvider authprovider = AuthProvider.Default,
+            string jwtOrPayload = null,
+            string storageDirectoryPath = null,
+            IThirdwebWallet siweSigner = null,
+            string legacyEncryptionKey = null,
+            string walletSecret = null
+        )
+        {
+            EcosystemId = ecosystemId;
+            EcosystemPartnerId = ecosystemPartnerId;
+            Email = email;
+            PhoneNumber = phoneNumber;
+            AuthProvider = authprovider;
+            JwtOrPayload = jwtOrPayload;
+            StorageDirectoryPath = storageDirectoryPath ?? Path.Combine(Application.persistentDataPath, "Thirdweb", "EcosystemWallet");
+            SiweSigner = siweSigner;
+            LegacyEncryptionKey = legacyEncryptionKey;
+            WalletSecret = walletSecret;
+        }
+    }
+
+    [Serializable]
+    public class SmartWalletOptions
+    {
+        [JsonProperty("sponsorGas")]
+        public bool SponsorGas;
+
+        [JsonProperty("factoryAddress")]
+        public string FactoryAddress;
+
+        [JsonProperty("accountAddressOverride")]
+        public string AccountAddressOverride;
+
+        [JsonProperty("entryPoint")]
+        public string EntryPoint;
+
+        [JsonProperty("bundlerUrl")]
+        public string BundlerUrl;
+
+        [JsonProperty("paymasterUrl")]
+        public string PaymasterUrl;
+
+        [JsonProperty("tokenPaymaster")]
+        public TokenPaymaster TokenPaymaster;
+
+        public SmartWalletOptions(
+            bool sponsorGas,
+            string factoryAddress = null,
+            string accountAddressOverride = null,
+            string entryPoint = null,
+            string bundlerUrl = null,
+            string paymasterUrl = null,
+            TokenPaymaster tokenPaymaster = TokenPaymaster.NONE
+        )
+        {
+            SponsorGas = sponsorGas;
+            FactoryAddress = factoryAddress;
+            AccountAddressOverride = accountAddressOverride;
+            EntryPoint = entryPoint;
+            BundlerUrl = bundlerUrl;
+            PaymasterUrl = paymasterUrl;
+            TokenPaymaster = tokenPaymaster;
+        }
+    }
+
+    [Serializable]
+    public class WalletOptions
+    {
+        [JsonProperty("provider")]
+        public WalletProvider Provider;
+
+        [JsonProperty("chainId")]
+        public BigInteger ChainId;
+
+        [JsonProperty("inAppWalletOptions")]
+        public InAppWalletOptions InAppWalletOptions;
+
+        [JsonProperty("ecosystemWalletOptions", NullValueHandling = NullValueHandling.Ignore)]
+        public EcosystemWalletOptions EcosystemWalletOptions;
+
+        [JsonProperty("smartWalletOptions", NullValueHandling = NullValueHandling.Ignore)]
+        public SmartWalletOptions SmartWalletOptions;
+
+        public WalletOptions(
+            WalletProvider provider,
+            BigInteger chainId,
+            InAppWalletOptions inAppWalletOptions = null,
+            EcosystemWalletOptions ecosystemWalletOptions = null,
+            SmartWalletOptions smartWalletOptions = null
+        )
+        {
+            Provider = provider;
+            ChainId = chainId;
+            InAppWalletOptions = inAppWalletOptions ?? new InAppWalletOptions();
+            SmartWalletOptions = smartWalletOptions;
+            EcosystemWalletOptions = ecosystemWalletOptions;
+        }
+    }
+
+    [Serializable]
+    public struct RpcOverride
+    {
+        public ulong ChainId;
+        public string RpcUrl;
+    }
+
+    [HelpURL("http://portal.thirdweb.com/unity/v5/thirdwebmanager")]
+    public abstract class ThirdwebManagerBase : MonoBehaviour
+    {
+        [field: SerializeField]
+        protected bool InitializeOnAwake { get; set; } = true;
+
+        [field: SerializeField]
+        protected bool ShowDebugLogs { get; set; } = true;
+
+        [field: SerializeField]
+        protected bool OptOutUsageAnalytics { get; set; } = false;
+
+        [field: SerializeField]
+        protected bool AutoConnectLastWallet { get; set; } = false;
+
+        [field: SerializeField]
+        protected ulong[] SupportedChains { get; set; } = new ulong[] { 421614 };
+
+        [field: SerializeField]
+        protected string[] IncludedWalletIds { get; set; } = null;
+
+        [field: SerializeField]
+        protected string RedirectPageHtmlOverride { get; set; } = null;
+
+        [field: SerializeField]
+        protected List<RpcOverride> RpcOverrides { get; set; } = null;
+
+        public ThirdwebClient Client { get; protected set; }
+        public IThirdwebWallet ActiveWallet { get; protected set; }
+        public bool Initialized { get; protected set; }
+
+        public static ThirdwebManagerBase Instance { get; protected set; }
+
+        public static readonly string THIRDWEB_UNITY_SDK_VERSION = "5.14.1";
+
+        protected const string THIRDWEB_AUTO_CONNECT_OPTIONS_KEY = "ThirdwebAutoConnectOptions";
+
+        protected Dictionary<string, IThirdwebWallet> _walletMapping;
+
+        protected abstract ThirdwebClient CreateClient();
+
+        protected abstract string MobileRedirectScheme { get; }
+
+        // ------------------------------------------------------
+        // Lifecycle Methods
+        // ------------------------------------------------------
+
+        protected virtual void Awake()
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+                DontDestroyOnLoad(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            ThirdwebDebug.IsEnabled = ShowDebugLogs;
+
+            if (InitializeOnAwake)
+            {
+                Initialize();
+            }
+        }
+
+        public virtual async void Initialize()
+        {
+            Client = CreateClient();
+            if (Client == null)
+            {
+                ThirdwebDebug.LogError("Failed to initialize ThirdwebManager.");
+                return;
+            }
+
+            ThirdwebDebug.Log("ThirdwebManager initialized.");
+
+            _walletMapping = new Dictionary<string, IThirdwebWallet>();
+
+            if (AutoConnectLastWallet && GetAutoConnectOptions(out var lastWalletOptions))
+            {
+                ThirdwebDebug.Log("Auto-connecting to last wallet.");
+                try
+                {
+                    _ = await ConnectWallet(lastWalletOptions);
+                    ThirdwebDebug.Log("Auto-connected to last wallet.");
+                }
+                catch (Exception e)
+                {
+                    ThirdwebDebug.LogError("Failed to auto-connect to last wallet: " + e.Message);
+                }
+            }
+
+            Initialized = true;
+        }
+
+        public virtual async Task<ThirdwebContract> GetContract(string address, BigInteger chainId, string abi = null)
+        {
+            if (!Initialized)
+            {
+                throw new InvalidOperationException("ThirdwebManager is not initialized.");
+            }
+
+            return await ThirdwebContract.Create(Client, address, chainId, abi);
+        }
+
+        public virtual IThirdwebWallet GetActiveWallet()
+        {
+            return ActiveWallet;
+        }
+
+        public virtual void SetActiveWallet(IThirdwebWallet wallet)
+        {
+            ActiveWallet = wallet;
+        }
+
+        public virtual IThirdwebWallet GetWallet(string address)
+        {
+            if (_walletMapping.TryGetValue(address, out var wallet))
+            {
+                return wallet;
+            }
+
+            throw new KeyNotFoundException($"Wallet with address {address} not found.");
+        }
+
+        public virtual async Task<IThirdwebWallet> AddWallet(IThirdwebWallet wallet)
+        {
+            var address = await wallet.GetAddress();
+            _walletMapping.TryAdd(address, wallet);
+            return wallet;
+        }
+
+        public virtual void RemoveWallet(string address)
+        {
+            if (_walletMapping.ContainsKey(address))
+            {
+                _walletMapping.Remove(address, out var _);
+            }
+        }
+
+        public virtual async Task<IThirdwebWallet> ConnectWallet(WalletOptions walletOptions)
+        {
+            if (walletOptions == null)
+            {
+                throw new ArgumentNullException(nameof(walletOptions));
+            }
+
+            if (walletOptions.ChainId <= 0)
+            {
+                throw new ArgumentException("ChainId must be greater than 0.");
+            }
+
+            IThirdwebWallet wallet = null;
+
+            switch (walletOptions.Provider)
+            {
+                case WalletProvider.PrivateKeyWallet:
+                    wallet = await PrivateKeyWallet.Generate(client: Client);
+                    break;
+
+                case WalletProvider.InAppWallet:
+                    wallet = await InAppWallet.Create(
+                        client: Client,
+                        email: walletOptions.InAppWalletOptions.Email,
+                        phoneNumber: walletOptions.InAppWalletOptions.PhoneNumber,
+                        authProvider: walletOptions.InAppWalletOptions.AuthProvider,
+                        storageDirectoryPath: walletOptions.InAppWalletOptions.StorageDirectoryPath,
+                        siweSigner: walletOptions.InAppWalletOptions.SiweSigner,
+                        legacyEncryptionKey: walletOptions.InAppWalletOptions.LegacyEncryptionKey
+                    );
+                    break;
+
+                case WalletProvider.EcosystemWallet:
+                    if (walletOptions.EcosystemWalletOptions == null)
+                    {
+                        throw new ArgumentException("EcosystemWalletOptions must be provided for EcosystemWallet provider.");
+                    }
+                    if (string.IsNullOrEmpty(walletOptions.EcosystemWalletOptions.EcosystemId))
+                    {
+                        throw new ArgumentException("EcosystemId must be provided for EcosystemWallet provider.");
+                    }
+                    wallet = await EcosystemWallet.Create(
+                        client: Client,
+                        ecosystemId: walletOptions.EcosystemWalletOptions.EcosystemId,
+                        ecosystemPartnerId: walletOptions.EcosystemWalletOptions.EcosystemPartnerId,
+                        email: walletOptions.EcosystemWalletOptions.Email,
+                        phoneNumber: walletOptions.EcosystemWalletOptions.PhoneNumber,
+                        authProvider: walletOptions.EcosystemWalletOptions.AuthProvider,
+                        storageDirectoryPath: walletOptions.EcosystemWalletOptions.StorageDirectoryPath,
+                        siweSigner: walletOptions.EcosystemWalletOptions.SiweSigner,
+                        legacyEncryptionKey: walletOptions.EcosystemWalletOptions.LegacyEncryptionKey
+                    );
+                    break;
+
+                case WalletProvider.WalletConnectWallet:
+                    var supportedChains = SupportedChains.Select(chain => new BigInteger(chain)).ToArray();
+                    var includedWalletIds = IncludedWalletIds == null || IncludedWalletIds.Length == 0 ? null : IncludedWalletIds;
+                    wallet = await WalletConnectWallet.Create(client: Client, initialChainId: walletOptions.ChainId, supportedChains: supportedChains, includedWalletIds: includedWalletIds);
+                    break;
+
+                case WalletProvider.MetaMaskWallet:
+                    wallet = await MetaMaskWallet.Create(client: Client, activeChainId: walletOptions.ChainId);
+                    break;
+            }
+
+            // InAppWallet auth flow
+            if (walletOptions.Provider == WalletProvider.InAppWallet && !await wallet.IsConnected())
+            {
+                ThirdwebDebug.Log("Session does not exist or is expired, proceeding with InAppWallet authentication.");
+
+                var inAppWallet = wallet as InAppWallet;
+                switch (walletOptions.InAppWalletOptions.AuthProvider)
+                {
+                    case AuthProvider.Default:
+                        await inAppWallet.SendOTP();
+                        _ = await InAppWalletModal.LoginWithOtp(inAppWallet);
+                        break;
+                    case AuthProvider.Siwe:
+                        _ = await inAppWallet.LoginWithSiwe(walletOptions.ChainId);
+                        break;
+                    case AuthProvider.JWT:
+                        _ = await inAppWallet.LoginWithJWT(walletOptions.InAppWalletOptions.JwtOrPayload);
+                        break;
+                    case AuthProvider.AuthEndpoint:
+                        _ = await inAppWallet.LoginWithAuthEndpoint(walletOptions.InAppWalletOptions.JwtOrPayload);
+                        break;
+                    case AuthProvider.Guest:
+                        _ = await inAppWallet.LoginWithGuest();
+                        break;
+                    case AuthProvider.Backend:
+                        _ = await inAppWallet.LoginWithBackend();
+                        break;
+                    default:
+                        _ = await inAppWallet.LoginWithOauth(
+                            isMobile: Application.isMobilePlatform,
+                            browserOpenAction: (url) => Application.OpenURL(url),
+                            mobileRedirectScheme: MobileRedirectScheme,
+                            browser: new CrossPlatformUnityBrowser(RedirectPageHtmlOverride)
+                        );
+                        break;
+                }
+            }
+
+            // EcosystemWallet auth flow
+            if (walletOptions.Provider == WalletProvider.EcosystemWallet && !await wallet.IsConnected())
+            {
+                ThirdwebDebug.Log("Session does not exist or is expired, proceeding with EcosystemWallet authentication.");
+
+                var ecosystemWallet = wallet as EcosystemWallet;
+                switch (walletOptions.EcosystemWalletOptions.AuthProvider)
+                {
+                    case AuthProvider.Default:
+                        await ecosystemWallet.SendOTP();
+                        _ = await EcosystemWalletModal.LoginWithOtp(ecosystemWallet);
+                        break;
+                    case AuthProvider.Siwe:
+                        _ = await ecosystemWallet.LoginWithSiwe(walletOptions.ChainId);
+                        break;
+                    case AuthProvider.JWT:
+                        _ = await ecosystemWallet.LoginWithJWT(walletOptions.EcosystemWalletOptions.JwtOrPayload);
+                        break;
+                    case AuthProvider.AuthEndpoint:
+                        _ = await ecosystemWallet.LoginWithAuthEndpoint(walletOptions.EcosystemWalletOptions.JwtOrPayload);
+                        break;
+                    case AuthProvider.Guest:
+                        _ = await ecosystemWallet.LoginWithGuest();
+                        break;
+                    case AuthProvider.Backend:
+                        _ = await ecosystemWallet.LoginWithBackend();
+                        break;
+                    default:
+                        _ = await ecosystemWallet.LoginWithOauth(
+                            isMobile: Application.isMobilePlatform,
+                            browserOpenAction: (url) => Application.OpenURL(url),
+                            mobileRedirectScheme: MobileRedirectScheme,
+                            browser: new CrossPlatformUnityBrowser(RedirectPageHtmlOverride)
+                        );
+                        break;
+                }
+            }
+
+            var address = await wallet.GetAddress();
+            var isSmartWallet = walletOptions.SmartWalletOptions != null;
+
+            if (!OptOutUsageAnalytics)
+            {
+                var typeString = isSmartWallet ? "smartWallet" : walletOptions.Provider.ToString()[..1].ToLower() + walletOptions.Provider.ToString()[1..];
+                TrackUsage("connectWallet", "connect", typeString, address);
+            }
+
+            SetAutoConnectOptions(walletOptions);
+
+            // If SmartWallet, do upgrade
+            if (isSmartWallet)
+            {
+                ThirdwebDebug.Log("Upgrading to SmartWallet.");
+                return await UpgradeToSmartWallet(wallet, walletOptions.ChainId, walletOptions.SmartWalletOptions);
+            }
+            else
+            {
+                await AddWallet(wallet);
+                SetActiveWallet(wallet);
+                return wallet;
+            }
+        }
+
+        public virtual async Task<SmartWallet> UpgradeToSmartWallet(IThirdwebWallet personalWallet, BigInteger chainId, SmartWalletOptions smartWalletOptions)
+        {
+            if (personalWallet.AccountType == ThirdwebAccountType.SmartAccount)
+            {
+                ThirdwebDebug.LogWarning("Wallet is already a SmartWallet.");
+                return personalWallet as SmartWallet;
+            }
+
+            if (smartWalletOptions == null)
+            {
+                throw new ArgumentNullException(nameof(smartWalletOptions));
+            }
+
+            if (chainId <= 0)
+            {
+                throw new ArgumentException("ChainId must be greater than 0.");
+            }
+
+            var wallet = await SmartWallet.Create(
+                personalWallet: personalWallet,
+                chainId: chainId,
+                gasless: smartWalletOptions.SponsorGas,
+                factoryAddress: smartWalletOptions.FactoryAddress,
+                accountAddressOverride: smartWalletOptions.AccountAddressOverride,
+                entryPoint: smartWalletOptions.EntryPoint,
+                bundlerUrl: smartWalletOptions.BundlerUrl,
+                paymasterUrl: smartWalletOptions.PaymasterUrl,
+                tokenPaymaster: smartWalletOptions.TokenPaymaster
+            );
+
+            await AddWallet(wallet);
+            SetActiveWallet(wallet);
+
+            // Persist "smartWalletOptions" to auto-connect
+            if (AutoConnectLastWallet && GetAutoConnectOptions(out var lastWalletOptions))
+            {
+                lastWalletOptions.SmartWalletOptions = smartWalletOptions;
+                SetAutoConnectOptions(lastWalletOptions);
+            }
+
+            return wallet;
+        }
+
+        public virtual async Task<List<LinkedAccount>> LinkAccount(IThirdwebWallet mainWallet, IThirdwebWallet walletToLink, string otp = null, BigInteger? chainId = null, string jwtOrPayload = null)
+        {
+            return await mainWallet.LinkAccount(
+                walletToLink: walletToLink,
+                otp: otp,
+                isMobile: Application.isMobilePlatform,
+                browserOpenAction: (url) => Application.OpenURL(url),
+                mobileRedirectScheme: MobileRedirectScheme,
+                browser: new CrossPlatformUnityBrowser(RedirectPageHtmlOverride),
+                chainId: chainId,
+                jwt: jwtOrPayload,
+                payload: jwtOrPayload
+            );
+        }
+
+        protected virtual bool GetAutoConnectOptions(out WalletOptions lastWalletOptions)
+        {
+            var connectOptionsStr = PlayerPrefs.GetString(THIRDWEB_AUTO_CONNECT_OPTIONS_KEY, null);
+            if (!string.IsNullOrEmpty(connectOptionsStr))
+            {
+                try
+                {
+                    lastWalletOptions = JsonConvert.DeserializeObject<WalletOptions>(connectOptionsStr);
+                    return true;
+                }
+                catch
+                {
+                    ThirdwebDebug.LogWarning("Failed to load last wallet options.");
+                    PlayerPrefs.DeleteKey(THIRDWEB_AUTO_CONNECT_OPTIONS_KEY);
+                    lastWalletOptions = null;
+                    return false;
+                }
+            }
+            lastWalletOptions = null;
+            return false;
+        }
+
+        protected virtual void SetAutoConnectOptions(WalletOptions walletOptions)
+        {
+            if (AutoConnectLastWallet && walletOptions.Provider != WalletProvider.WalletConnectWallet)
+            {
+                try
+                {
+                    PlayerPrefs.SetString(THIRDWEB_AUTO_CONNECT_OPTIONS_KEY, JsonConvert.SerializeObject(walletOptions));
+                }
+                catch
+                {
+                    ThirdwebDebug.LogWarning("Failed to save last wallet options.");
+                    PlayerPrefs.DeleteKey(THIRDWEB_AUTO_CONNECT_OPTIONS_KEY);
+                }
+            }
+        }
+
+        protected virtual async void TrackUsage(string source, string action, string walletType, string walletAddress)
+        {
+            if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(action) || string.IsNullOrEmpty(walletType) || string.IsNullOrEmpty(walletAddress))
+            {
+                ThirdwebDebug.LogWarning("Invalid usage analytics parameters.");
+                return;
+            }
+
+            try
+            {
+                var content = new System.Net.Http.StringContent(
+                    JsonConvert.SerializeObject(
+                        new
+                        {
+                            source,
+                            action,
+                            walletAddress,
+                            walletType,
+                        }
+                    ),
+                    System.Text.Encoding.UTF8,
+                    "application/json"
+                );
+                _ = await Client.HttpClient.PostAsync("https://c.thirdweb.com/event", content);
+            }
+            catch
+            {
+                ThirdwebDebug.LogWarning("Failed to report usage analytics.");
+            }
+        }
+    }
+}

--- a/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerBase.cs.meta
+++ b/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bd1bb5e5d7733646a69989260142701
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerServer.cs
+++ b/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerServer.cs
@@ -4,37 +4,26 @@ using System.Numerics;
 
 namespace Thirdweb.Unity
 {
-    public class ThirdwebManager : ThirdwebManagerBase
+    public class ThirdwebManagerServer : ThirdwebManagerBase
     {
         [field: SerializeField]
-        private string ClientId { get; set; }
+        private string SecretKey { get; set; }
 
-        [field: SerializeField]
-        private string BundleId { get; set; }
-
-        public new static ThirdwebManager Instance
+        public new static ThirdwebManagerServer Instance
         {
-            get => ThirdwebManagerBase.Instance as ThirdwebManager;
+            get => ThirdwebManagerBase.Instance as ThirdwebManagerServer;
         }
 
         protected override ThirdwebClient CreateClient()
         {
-            if (string.IsNullOrEmpty(ClientId))
+            if (string.IsNullOrEmpty(SecretKey))
             {
-                ThirdwebDebug.LogError("ClientId must be set in order to initialize ThirdwebManager. " + "Get your API key from https://thirdweb.com/create-api-key");
+                ThirdwebDebug.LogError("SecretKey must be set in order to initialize ThirdwebManagerServer.");
                 return null;
             }
 
-            if (string.IsNullOrEmpty(BundleId))
-            {
-                BundleId = null;
-            }
-
-            BundleId ??= Application.identifier ?? $"com.{Application.companyName}.{Application.productName}";
-
             return ThirdwebClient.Create(
-                clientId: ClientId,
-                bundleId: BundleId,
+                secretKey: SecretKey,
                 httpClient: new CrossPlatformUnityHttpClient(),
                 sdkName: Application.platform == RuntimePlatform.WebGLPlayer ? "UnitySDK_WebGL" : "UnitySDK",
                 sdkOs: Application.platform.ToString(),
@@ -46,6 +35,6 @@ namespace Thirdweb.Unity
             );
         }
 
-        protected override string MobileRedirectScheme => BundleId + "://";
+        protected override string MobileRedirectScheme => "tw-server://";
     }
 }

--- a/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerServer.cs.meta
+++ b/Assets/Thirdweb/Runtime/Unity/ThirdwebManagerServer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a197f9da6b1311840bb25b207982e287
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Thirdweb/Runtime/Unity/ThirdwebUnityExtensions.cs
+++ b/Assets/Thirdweb/Runtime/Unity/ThirdwebUnityExtensions.cs
@@ -25,7 +25,7 @@ namespace Thirdweb.Unity
 
         public static async Task<SmartWallet> UpgradeToSmartWallet(this IThirdwebWallet personalWallet, BigInteger chainId, SmartWalletOptions smartWalletOptions)
         {
-            return await ThirdwebManager.Instance.UpgradeToSmartWallet(personalWallet, chainId, smartWalletOptions);
+            return await ThirdwebManagerBase.Instance.UpgradeToSmartWallet(personalWallet, chainId, smartWalletOptions);
         }
 
         public static Texture2D ToQRTexture(this string textForEncoding, Color? fgColor = null, Color? bgColor = null, int width = 512, int height = 512)


### PR DESCRIPTION
Adds `AuthProvider.Backend`'s related `walletSecret` In-App and Ecosystem Wallet Options Parameter.

Splits ThirdwebManager (and its editor script) into ThirdwebManagerBase, ThirdwebManager (frontend), ThirdwebManagerServer (Backend)

Adds ThirdwebManagerServer prefab, uses SecretKey instead of ClientId and BundleId.

Adds a lot of flexibility and extendability for various use cases.

Closes TOOL-3022

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `ThirdwebManager` class to inherit from `ThirdwebManagerBase`, enhancing the structure and functionality of wallet management in the Thirdweb Unity SDK.

### Detailed summary
- Refactored `ThirdwebManager` to inherit from `ThirdwebManagerBase`.
- Updated method calls to use `ThirdwebManagerBase.Instance`.
- Added `SecretKey` property in `ThirdwebManagerServer`.
- Implemented `ThirdwebManagerServer` class for server-side functionality.
- Modified editor scripts to support new structure.
- Enhanced error handling and logging for wallet connections.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->