### PR TITLE
Future-proof dynCalls

### DIFF
--- a/Assets/Thirdweb/Plugins/ThreadingPatcher/Plugins/SystemThreadingTimer.jslib
+++ b/Assets/Thirdweb/Plugins/ThreadingPatcher/Plugins/SystemThreadingTimer.jslib
@@ -15,7 +15,7 @@ var SystemThreadingTimerLib = {
 		setTimeout(function()
 		{
 			if (id === vars.currentCallbackId)
-				Runtime.dynCall('v', vars.callback);
+				{{{ makeDynCall("v", "vars.callback") }}}();
 		},
 		interval);
 	}

--- a/Assets/Thirdweb/Plugins/WalletConnectUnity/com.walletconnect.core/Runtime/External/NativeWebSocket/WebSocket.jslib
+++ b/Assets/Thirdweb/Plugins/WalletConnectUnity/com.walletconnect.core/Runtime/External/NativeWebSocket/WebSocket.jslib
@@ -150,7 +150,7 @@ var LibraryWebSocket = {
 				console.log("[JSLIB WebSocket] Connected.");
 
 			if (webSocketState.onOpen)
-				Module.dynCall_vi(webSocketState.onOpen, instanceId);
+				{{{ makeDynCall("vi", "webSocketState.onOpen") }}}(instanceId);
 
 		};
 
@@ -170,7 +170,7 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					{{{ makeDynCall("viii", "webSocketState.onMessage") }}}(instanceId, buffer, dataBuffer.length);
 				} finally {
 					_free(buffer);
 				}
@@ -182,7 +182,7 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					{{{ makeDynCall("viii", "webSocketState.onMessage") }}}(instanceId, buffer, dataBuffer.length);
 				} finally {
 					_free(buffer);
 				}
@@ -204,7 +204,7 @@ var LibraryWebSocket = {
 				stringToUTF8(msg, buffer, length);
 
 				try {
-					Module.dynCall_vii(webSocketState.onError, instanceId, buffer);
+					{{{ makeDynCall("vii", "webSocketState.onError") }}}(instanceId, buffer);
 				} finally {
 					_free(buffer);
 				}
@@ -219,7 +219,7 @@ var LibraryWebSocket = {
 				console.log("[JSLIB WebSocket] Closed.");
 
 			if (webSocketState.onClose)
-				Module.dynCall_vii(webSocketState.onClose, instanceId, ev.code);
+					{{{ makeDynCall("vii", "webSocketState.onClose") }}}(instanceId, ev.code);
 
 			delete instance.ws;
 

--- a/Assets/Thirdweb/Plugins/WebGLInputCopy/WebGLInput/Mobile/WebGLInputMobile.jslib
+++ b/Assets/Thirdweb/Plugins/WebGLInputCopy/WebGLInput/Mobile/WebGLInputMobile.jslib
@@ -6,7 +6,7 @@ var WebGLInputMobile = {
 
         document.body.addEventListener("touchend", function () {
             document.body.removeEventListener("touchend", arguments.callee);
-            Runtime.dynCall("vi", touchend, [id]);
+            {{{ makeDynCall("vi", "touchend") }}}(id);
         });
 
         return id;
@@ -14,7 +14,7 @@ var WebGLInputMobile = {
     WebGLInputMobileOnFocusOut: function (id, focusout) {
         document.body.addEventListener("focusout", function () {
             document.body.removeEventListener("focusout", arguments.callee);
-            Runtime.dynCall("vi", focusout, [id]);
+            {{{ makeDynCall("vi", "focusout") }}}(id);
         });
     },
 }

--- a/Assets/Thirdweb/Plugins/WebGLInputCopy/WebGLInput/WebGLInput.jslib
+++ b/Assets/Thirdweb/Plugins/WebGLInputCopy/WebGLInput/WebGLInput.jslib
@@ -1,19 +1,6 @@
 var WebGLInput = {
     $instances: [],
     WebGLInputInit : function() {
-        // use WebAssembly.Table : makeDynCall
-        // when enable. dynCall is undefined
-        if(typeof dynCall === "undefined")
-        {
-            // make Runtime.dynCall to undefined
-            Runtime = { dynCall : undefined }
-        }
-        else
-        {
-            // Remove the `Runtime` object from "v1.37.27: 12/24/2017"
-            // if Runtime not defined. create and add functon!!
-            if(typeof Runtime === "undefined") Runtime = { dynCall : dynCall }
-        }
     },
     WebGLInputCreate: function (canvasId, x, y, width, height, fontsize, text, placeholder, isMultiLine, isPassword, isHidden, isMobile) {
 
@@ -112,7 +99,7 @@ var WebGLInput = {
                     input.setSelectionRange(start + 1, start + 1);
                     input.oninput();	// call oninput to exe ValueChange function!!
                 } else {
-                    (!!Runtime.dynCall) ? Runtime.dynCall("vii", cb, [id, e.shiftKey ? -1 : 1]) : {{{ makeDynCall("vii", "cb") }}}(id, e.shiftKey ? -1 : 1);
+                    {{{ makeDynCall("vii", "cb") }}}(id, e.shiftKey ? -1 : 1);
                 }
             }
         });
@@ -124,13 +111,13 @@ var WebGLInput = {
     WebGLInputOnFocus: function (id, cb) {
         var input = instances[id];
         input.onfocus = function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("vi", cb, [id]) : {{{ makeDynCall("vi", "cb") }}}(id);
+            {{{ makeDynCall("vi", "cb") }}}(id);
         };
     },
     WebGLInputOnBlur: function (id, cb) {
         var input = instances[id];
         input.onblur = function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("vi", cb, [id]) : {{{ makeDynCall("vi", "cb") }}}(id);
+            {{{ makeDynCall("vi", "cb") }}}(id);
         };
     },
     WebGLInputIsFocus: function (id) {
@@ -143,7 +130,7 @@ var WebGLInput = {
             var bufferSize = lengthBytesUTF8(returnStr) + 1;
             var buffer = _malloc(bufferSize);
             stringToUTF8(returnStr, buffer, bufferSize);
-            (!!Runtime.dynCall) ? Runtime.dynCall("vii", cb, [id, buffer]) : {{{ makeDynCall("vii", "cb") }}}(id, buffer);
+            {{{ makeDynCall("vii", "cb") }}}(id, buffer);
         };
     },
     WebGLInputOnEditEnd:function(id, cb){
@@ -153,7 +140,7 @@ var WebGLInput = {
             var bufferSize = lengthBytesUTF8(returnStr) + 1;
             var buffer = _malloc(bufferSize);
             stringToUTF8(returnStr, buffer, bufferSize);
-            (!!Runtime.dynCall) ? Runtime.dynCall("vii", cb, [id, buffer]) : {{{ makeDynCall("vii", "cb") }}}(id, buffer);
+            {{{ makeDynCall("vii", "cb") }}}(id, buffer);
         };
     },
     WebGLInputOnKeyboardEvent:function(id, cb){
@@ -167,7 +154,7 @@ var WebGLInput = {
                 var shift = e.shiftKey ? 1 : 0;
                 var ctrl = e.ctrlKey ? 1 : 0;
                 var alt = e.altKey ? 1 : 0;
-                (!!Runtime.dynCall) ? Runtime.dynCall("viiiiiii", cb, [id, mode, key, code, shift, ctrl, alt]) : {{{ makeDynCall("viiiiiii", "cb") }}}(id, mode, key, code, shift, ctrl, alt);
+                {{{ makeDynCall("viiiiiii", "cb") }}}(id, mode, key, code, shift, ctrl, alt);
             }
         }
         input.addEventListener('keydown', function(e) { func(1, e); });

--- a/Assets/Thirdweb/Plugins/WebGLInputCopy/WebGLWindow/WebGLWindow.jslib
+++ b/Assets/Thirdweb/Plugins/WebGLInputCopy/WebGLWindow/WebGLWindow.jslib
@@ -1,18 +1,9 @@
+#if parseInt(EMSCRIPTEN_VERSION.split('.')[0]) < 2 || (parseInt(EMSCRIPTEN_VERSION.split('.')[0]) == 2 && parseInt(EMSCRIPTEN_VERSION.split('.')[1]) < 0) || (parseInt(EMSCRIPTEN_VERSION.split('.')[0]) == 2 && parseInt(EMSCRIPTEN_VERSION.split('.')[1]) == 0 && parseInt(EMSCRIPTEN_VERSION.split('.')[2]) < 3)
+#error "ThirdWeb plugin requires building with Emscripten 2.0.3 and Unity 2021.2 or newer. Please update"
+#endif
+
 var WebGLWindow = {
     WebGLWindowInit : function() {
-        // use WebAssembly.Table : makeDynCall
-        // when enable. dynCall is undefined
-        if(typeof dynCall === "undefined")
-        {
-            // make Runtime.dynCall to undefined
-            Runtime = { dynCall : undefined }
-        }
-        else
-        {
-            // Remove the `Runtime` object from "v1.37.27: 12/24/2017"
-            // if Runtime not defined. create and add functon!!
-            if(typeof Runtime === "undefined") Runtime = { dynCall : dynCall }
-        }
     },
     WebGLWindowGetCanvasName: function() {
         var elements = document.getElementsByTagName('canvas');
@@ -33,17 +24,17 @@ var WebGLWindow = {
     },
     WebGLWindowOnFocus: function (cb) {
         window.addEventListener('focus', function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}();
+            {{{ makeDynCall("v", "cb") }}}();
         });
     },
     WebGLWindowOnBlur: function (cb) {
         window.addEventListener('blur', function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}();
+            {{{ makeDynCall("v", "cb") }}}();
         });
     },
     WebGLWindowOnResize: function(cb) {
         window.addEventListener('resize', function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}();
+            {{{ makeDynCall("v", "cb") }}}();
         });
     },
     WebGLWindowInjectFullscreen : function () {


### PR DESCRIPTION
Closes TOOL-3700

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the code to replace direct calls to `Runtime.dynCall` and `Module.dynCall` with a new `makeDynCall` function, enhancing the code's maintainability and readability.

### Detailed summary
- Replaced `Runtime.dynCall` with `{{{ makeDynCall("v", "vars.callback") }}}()` in `SystemThreadingTimer.jslib`.
- Updated `touchend` and `focusout` event listeners in `WebGLInputMobile.jslib` to use `makeDynCall`.
- Changed WebSocket callback calls in `WebSocket.jslib` to `makeDynCall`.
- Removed checks for `Runtime.dynCall` in `WebGLWindow.jslib` and `WebGLInput.jslib`, simplifying the code.
- Unified the callback invocation method across multiple functions in `WebGLInput.jslib`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->