### PR TITLE
fix: prevent Reown wallet WebGL deadlock when fetching chain metadata

### DIFF
--- a/Assets/Thirdweb/Runtime/Unity/Wallets/Reown/ReownWallet.cs
+++ b/Assets/Thirdweb/Runtime/Unity/Wallets/Reown/ReownWallet.cs
@@ -47,7 +47,7 @@ namespace Thirdweb.Unity
             else
             {
                 ThirdwebDebug.Log($"The chain with ID {activeChainId} is not supported by Reown. Adding it manually.");
-                wcChains.Add(ToWcChain(client, activeChainId));
+                wcChains.Add(await ToWcChainAsync(client, activeChainId));
             }
 
             var appKitConfig = new AppKitConfig
@@ -258,11 +258,12 @@ namespace Thirdweb.Unity
 
         public async Task SwitchNetwork(BigInteger chainId)
         {
-            await AppKit.NetworkController.ChangeActiveChainAsync(ToWcChain(this.Client, chainId));
+            var targetChain = await ToWcChainAsync(this.Client, chainId);
+            await AppKit.NetworkController.ChangeActiveChainAsync(targetChain);
             ThirdwebDebug.Log($"Switched Reown to chain ID {chainId}.");
         }
 
-        internal static Chain ToWcChain(ThirdwebClient client, BigInteger chainId)
+        internal static async Task<Chain> ToWcChainAsync(ThirdwebClient client, BigInteger chainId)
         {
             var wcChain = ChainConstants.Chains.All.FirstOrDefault(c => c.ChainReference == chainId.ToString());
 
@@ -271,7 +272,7 @@ namespace Thirdweb.Unity
                 return wcChain;
             }
 
-            var twChainMeta = Utils.GetChainMetadata(client, chainId).GetAwaiter().GetResult();
+            var twChainMeta = await Utils.GetChainMetadata(client, chainId);
             return new Chain(
                 chainNamespace: ChainConstants.Namespaces.Evm,
                 chainReference: chainId.ToString(),


### PR DESCRIPTION
## Summary
Fixes a WebGL deadlock caused by calling Utils.GetChainMetadata synchronously in ReownWallet. WebGL runs on a single-threaded runtime, so the .GetAwaiter().GetResult() call blocked the continuation forever.

## Changes
* Refactors ToWcChain into the async helper ToWcChainAsync
* Updates all call sites (Create, SwitchNetwork) to await the metadata lookup
* Keeps the fast path when the chain already exists in ChainConstants
* After this change, Reown wallet initialization and chain switching complete successfully on WebGL while other platforms keep their behavior

## Testing
* WebGL build: confirmed the wallet connect flow and chain switch complete without hanging

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on converting synchronous methods to asynchronous ones in the `ReownWallet` class, improving the handling of network changes and chain conversions.

### Detailed summary
- Changed `ToWcChain` method to `ToWcChainAsync`, making it asynchronous.
- Updated calls to `ToWcChain` to use `ToWcChainAsync`.
- Modified `SwitchNetwork` to await the result of `ToWcChainAsync`.
- Adjusted the retrieval of chain metadata to be asynchronous.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Migrated wallet chain resolution and network switching to asynchronous operations for smoother, more responsive interactions.
  - Improves experience when adding or switching networks by reducing blocking behavior and wait times.

- **Bug Fixes**
  - Mitigates occasional stalls during network changes, enhancing reliability of wallet connectivity.

- **Chores**
  - Internal method updates to align with asynchronous flow, ensuring consistent behavior across wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->